### PR TITLE
Enable copr builds for centos-stream

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -27,6 +27,8 @@ jobs:
     trigger: pull_request
     targets:
       - fedora-all
+      - centos-stream-9
+      - centos-stream-10
     packages:
       - kdump-utils
 


### PR DESCRIPTION
### **PR Type**
enhancement, configuration changes


___

### **Description**
- Added support for copr builds on CentOS Stream 9 and 10.

- Updated `.packit.yaml` to include new CentOS Stream targets.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>.packit.yaml</strong><dd><code>Add CentOS Stream 9 and 10 to copr builds</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.packit.yaml

<li>Added <code>centos-stream-9</code> and <code>centos-stream-10</code> to copr build targets.<br> <li> Enhanced configuration for broader platform support.


</details>


  </td>
  <td><a href="https://github.com/coiby/kdump-utils/pull/9/files#diff-2b4300f6d69654fd71c0cdd329b5a5f13fa8fe7eb709c76276bdfd3ea1dde578">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>