### PR TITLE
Fips tests

### DIFF
--- a/.github/workflows/testing_farm.yml
+++ b/.github/workflows/testing_farm.yml
@@ -1,0 +1,29 @@
+name: Testing-farm kdump-utils tests
+
+on:
+  workflow_run:
+    workflows: [rpm-build:fedora-40-x86_64]
+    types: 
+      - completed
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+    strategy:
+        matrix:
+            arch: ["x86_64"]
+        fail-fast: false
+    steps:
+      - name: Schedule test on Testing Farm
+        uses: sclorg/testing-farm-as-github-action@v3
+        with:
+          api_key: ${{ secrets.TF_API_KEY }}
+          git_url: https://gitlab.com/coxu/kernel-tests.git
+          git_ref: testing_farm_v4_beaker
+          compose: Fedora-40
+          arch: ${{ matrix.arch }}
+          tmt_plan_regex: "nfs_fips$"
+          variables: KDUMP_UTILS_RPM=kdump-utils*${{ github.event.number }}* RESOURCE_URL=https://gitlab.cee.redhat.com/kernel-qe/kernel/-/raw/master/kdump/internal/internal_resources.sh AUTO_CONFIG=auto
+          copr: "packit/coiby-kdump-utils-${{ github.event.number }}:fedora-40-${{ matrix.arch }}"
+          create_issue_comment: 'true'
+          create_github_summary: 'true'
+          pull_request_status_name: 'Testing-farm kdump-utils tests for ${{ matrix.arch }}'

--- a/.packit.yaml
+++ b/.packit.yaml
@@ -26,7 +26,7 @@ jobs:
   - job: copr_build
     trigger: pull_request
     targets:
-      - fedora-all
+      - fedora-40
     packages:
       - kdump-utils
 

--- a/.packit.yaml
+++ b/.packit.yaml
@@ -26,9 +26,24 @@ jobs:
   - job: copr_build
     trigger: pull_request
     targets:
-      - fedora-40
+      - centos-stream-10-x86_64
+      - centos-stream-10-aarch64
     packages:
       - kdump-utils
+
+  - job: tests
+    trigger: pull_request
+    targets:
+      - centos-stream-10
+      - centos-stream-10-aarch64
+    fmf_url: https://gitlab.com/coxu/kernel-tests.git
+    fmf_ref: testing_farm_v5_beaker
+    tmt_plan: local$
+    tf_extra_params:
+      environments:
+        - variables:
+            RESOURCE_URL: https://gitlab.cee.redhat.com/kernel-qe/kernel/-/raw/master/kdump/internal/internal_resources.sh
+            AUTO_CONFIG: auto
 
   - job: koji_build
     trigger: commit


### PR DESCRIPTION
### **PR Type**
Tests, Configuration changes


___

### **Description**
- Added a GitHub workflow for Testing Farm kdump-utils tests.

- Limited COPR build target to Fedora 40 in `.packit.yaml`.

- Configured Testing Farm to run NFS kdump tests with specific parameters.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>testing_farm.yml</strong><dd><code>Add Testing Farm workflow for kdump-utils tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/testing_farm.yml

<li>Introduced a new GitHub workflow for Testing Farm.<br> <li> Configured the workflow to trigger after COPR builds.<br> <li> Added parameters for NFS kdump tests and environment variables.


</details>


  </td>
  <td><a href="https://github.com/coiby/kdump-utils/pull/10/files#diff-f3fd9ba46d10c1eaa2d8460d1a74d8fa986178415d59877fdd077c111e2de845">+29/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>.packit.yaml</strong><dd><code>Restrict COPR build target to Fedora 40</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.packit.yaml

<li>Updated COPR build target to Fedora 40.<br> <li> Removed support for building on all Fedora versions.


</details>


  </td>
  <td><a href="https://github.com/coiby/kdump-utils/pull/10/files#diff-2b4300f6d69654fd71c0cdd329b5a5f13fa8fe7eb709c76276bdfd3ea1dde578">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>