### PR TITLE
Image mode

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -37,13 +37,12 @@ jobs:
         runs-on: self-hosted
         timeout-minutes: 45
         concurrency:
-            group: ${{ github.workflow }}-${{ github.ref }}-${{ matrix.fedora_version }}-${{ matrix.test }}
+            group: ${{ github.workflow }}-${{ github.ref }}-${{ matrix.fedora_version }}-${{ matrix.deployment_mode }}
             cancel-in-progress: true
         strategy:
             matrix:
-                fedora_version: [
-                        "40", "rawhide"
-                ]
+                fedora_version: ["40", "rawhide"]
+                deployment_mode: ["package", "image"]
             fail-fast: false
         steps:
             -   name: "Checkout Repository"
@@ -51,4 +50,8 @@ jobs:
                 with:
                     fetch-depth: 0
             -   name: "${{ matrix.fedora_version }} kdump tests"
-                run: tools/run-integration-tests.sh ${{ matrix.fedora_version }}
+                run: tools/run-integration-tests.sh --fedora_version=${{ matrix.fedora_version }} --deployment_mode=${{ matrix.deployment_mode }}
+                env:
+                  KDUMP_UTILS_RPM: kdump-utils*pr${{github.event.number}}*
+                  CUSTOM_MIRROR: https://mirror.tuna.tsinghua.edu.cn/fedora/
+                  COPR_REPO_URL: https://copr.fedorainfracloud.org/coprs/packit/${{github.repository_owner}}-kdump-utils-${{github.event.number}}/repo/fedora-40/packit-${{github.repository_owner}}-kdump-utils-${{github.event.number}}-fedora-${{ matrix.fedora_version }}.repo

--- a/.packit.yaml
+++ b/.packit.yaml
@@ -26,7 +26,10 @@ jobs:
   - job: copr_build
     trigger: pull_request
     targets:
-      - fedora-all
+      - fedora-40
+      - fedora-40-rawhide
+      - fedora-40-aarch64
+      - fedora-rawhide-aarch64
     packages:
       - kdump-utils
 

--- a/kdumpctl
+++ b/kdumpctl
@@ -1509,7 +1509,9 @@ reset_crashkernel()
 				;;
 			--kernel=*)
 				_val=${_opt#*=}
-				if ! _valid_grubby_kernel_path "$_val"; then
+				if is_ostree; then
+					ddebug "--kernel doesn't apply to OSTree, ignore it."
+				elif ! _valid_grubby_kernel_path "$_val"; then
 					derror "Invalid $_opt, please specify a valid kernel path, ALL or DEFAULT"
 					exit
 				fi

--- a/tests/plans/local.fmf
+++ b/tests/plans/local.fmf
@@ -3,10 +3,11 @@ enabled: true
 # Disable this plan due to https://bugzilla.redhat.com/show_bug.cgi?id=2270423
 adjust:
     enabled: false
-    when: distro == fedora
+    when: distro == fedora and deployment_mode == package
 discover:
     how: fmf
     test:
+     - /setup/install_kdump-utils
      - /setup/default_crashkernel
      - /setup/trigger_crash
      - /tests/check_vmcore/local

--- a/tests/plans/lvm2_thinp.fmf
+++ b/tests/plans/lvm2_thinp.fmf
@@ -2,6 +2,7 @@ summary: Kdump LVM2 provision dumping
 discover:
     how: fmf
     test:
+     - /setup/install_kdump-utils
      - /setup/default_crashkernel
      - /setup/lvm2_thinp
      - /setup/trigger_crash

--- a/tests/plans/main.fmf
+++ b/tests/plans/main.fmf
@@ -14,8 +14,7 @@ prepare:
     order: 30
     how: shell
     script:
-      - test -v CUSTOM_MIRROR && sed -e 's/^metalink=/#metalink=/g' -e "s|^#baseurl=http://download.example/pub/fedora/linux|baseurl=${CUSTOM_MIRROR}|g" -i.bak /etc/yum.repos.d/fedora*.repo || true
-      - dnf config-manager --set-disabled fedora-cisco-openh264 || true
+      - test -v CUSTOM_MIRROR && sed -e 's/^metalink=/#metalink=/g' -e "s|^#baseurl=http://download.example/pub/fedora/linux|baseurl=${CUSTOM_MIRROR}|g" -i.bak /etc/yum.repos.d/fedora{,-updates}.repo || true
 
   # Set root password to log in as root in the console
   - name: Set root password

--- a/tests/plans/main.fmf
+++ b/tests/plans/main.fmf
@@ -22,15 +22,6 @@ prepare:
     script:
       - echo root:kdump | chpasswd
 
-  - name: Install built RPM
-    how: install
-    package:
-      - "$KDUMP_UTILS_RPM"
-    when: deployment_mode == package
-    where:
-      - client
-
-
 execute:
     how: tmt
     exit-first: true

--- a/tests/plans/main.fmf
+++ b/tests/plans/main.fmf
@@ -27,6 +27,7 @@ prepare:
     how: install
     package:
       - "$KDUMP_UTILS_RPM"
+    when: deployment_mode == package
     where:
       - client
 

--- a/tests/plans/nfs.fmf
+++ b/tests/plans/nfs.fmf
@@ -4,6 +4,10 @@ adjust:
     enabled: false
     when: distro > fedora-40
 discover:
+  - name: Install kdump-utils
+    how: fmf
+    test:
+     - setup/install_kdump-utils
   - name: Set up crashkernel
     how: fmf
     test:

--- a/tests/plans/nfs_early.fmf
+++ b/tests/plans/nfs_early.fmf
@@ -4,6 +4,12 @@ adjust:
     enabled: false
     when: distro > fedora-40
 discover:
+  - name: Install kdump-utils
+    how: fmf
+    test:
+     - setup/install_kdump-utils
+    where:
+      - client
   - name: Set up crashkernel
     how: fmf
     test:

--- a/tests/plans/ssh.fmf
+++ b/tests/plans/ssh.fmf
@@ -4,6 +4,10 @@ adjust:
   enabled: false
   when: distro == fedora-rawhide
 discover:
+  - name: Install kdump-utils
+    how: fmf
+    test:
+     - setup/install_kdump-utils
   - name: Set up crashkernel
     how: fmf
     test:

--- a/tests/setup/install_kdump-utils/main.fmf
+++ b/tests/setup/install_kdump-utils/main.fmf
@@ -1,7 +1,3 @@
 summary: Install kdump-utils
 test: ./test.sh
 framework: beakerlib
-enabled: false
-adjust:
-    enabled: true
-    when: deployment_mode == image

--- a/tests/setup/install_kdump-utils/main.fmf
+++ b/tests/setup/install_kdump-utils/main.fmf
@@ -1,0 +1,7 @@
+summary: Install kdump-utils
+test: ./test.sh
+framework: beakerlib
+enabled: false
+adjust:
+    enabled: true
+    when: deployment_mode == image

--- a/tests/setup/install_kdump-utils/test.sh
+++ b/tests/setup/install_kdump-utils/test.sh
@@ -44,6 +44,8 @@ rlJournalStart
             fi
             rlRun "rpm-ostree override replace $KDUMP_UTILS_RPM" 0 "Install kdump-utils"
             rlRun "rpm-ostree apply-live --allow-replacement" 0 "Apply overrides live"
+        else
+            rlRun "dnf install $KDUMP_UTILS_RPM -y" 0 "Install kdump-utils"
         fi
     fi
     rlPhaseEnd

--- a/tests/setup/install_kdump-utils/test.sh
+++ b/tests/setup/install_kdump-utils/test.sh
@@ -37,6 +37,7 @@ rlJournalStart
     fi
 
     if [[ -n "$KDUMP_UTILS_RPM" ]]; then
+        grep -qs -E "\.rpm$"<<< "$KDUMP_UTILS_RPM" && KDUMP_UTILS_RPM="$TMT_TREE/$KDUMP_UTILS_RPM"
         if test -f /run/ostree-booted; then
             if [[ -n "$COPR_REPO_URL" ]]; then
                 rlRun "rpm-ostree install -A --allow-inactive --idempotent dnf-plugins-core -y" 0 "Install dnf-plugins-core"

--- a/tests/setup/install_kdump-utils/test.sh
+++ b/tests/setup/install_kdump-utils/test.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+# vim: dict+=/usr/share/beakerlib/dictionary.vim cpt=.,w,b,u,t,i,k
+. /usr/share/beakerlib/beakerlib.sh || exit 1
+
+download_copr_repo() {
+    # Maximum wait time in seconds
+    MAX_WAIT=120
+    # Retry interval in seconds
+    RETRY_INTERVAL=5
+    # Track elapsed time
+    ELAPSED_TIME=0
+
+    DESTINATION="/etc/yum.repos.d/$(basename "$COPR_REPO_URL")"
+
+    while [ "$ELAPSED_TIME" -lt "$MAX_WAIT" ]; do
+        echo "Attempting to download COPR repo..."
+
+        # Try to download the repo file
+        if curl -fSL "$COPR_REPO_URL" -o "$DESTINATION"; then
+            echo "Successfully downloaded COPR repo to $DESTINATION"
+            return 0
+        else
+            echo "Repo not available. Retrying in $RETRY_INTERVAL seconds..."
+            sleep "$RETRY_INTERVAL"
+            ELAPSED_TIME=$((ELAPSED_TIME + RETRY_INTERVAL))
+        fi
+    done
+
+    echo "Failed to download COPR repo after $MAX_WAIT seconds. Exiting."
+    return 1
+}
+
+rlJournalStart
+    rlPhaseStartTest
+    if [[ -n "$COPR_REPO_URL" ]]; then
+        rlRun "download_copr_repo" 0 "Enable COPR project"
+    fi
+
+    if [[ -n "$KDUMP_UTILS_RPM" ]]; then
+        if test -f /run/ostree-booted; then
+            if [[ -n "$COPR_REPO_URL" ]]; then
+                rlRun "rpm-ostree install -A --allow-inactive --idempotent dnf-plugins-core -y" 0 "Install dnf-plugins-core"
+                rlRun "dnf download $KDUMP_UTILS_RPM" 0 "Download kdump-utils"
+            fi
+            rlRun "rpm-ostree override replace $KDUMP_UTILS_RPM" 0 "Install kdump-utils"
+            rlRun "rpm-ostree apply-live --allow-replacement" 0 "Apply overrides live"
+        fi
+    fi
+    rlPhaseEnd
+
+rlJournalEnd

--- a/tools/run-integration-tests.sh
+++ b/tools/run-integration-tests.sh
@@ -58,4 +58,4 @@ if [[ ! -e $test_image ]]; then
 	test_image=fedora:"$fedora_version"
 fi
 
-cd tests && tmt --context distro="fedora-${fedora_version}" --context deployment_mode="$deployment_mode" run --environment CUSTOM_MIRROR="$mirror" --environment KDUMP_UTILS_RPM="$rpm_path" -a provision -h virtual -i "$test_image"
+cd tests && tmt --context distro="fedora-${fedora_version}" --context deployment_mode="$deployment_mode" run --environment COPR_REPO_URL="$COPR_REPO_URL" --environment CUSTOM_MIRROR="$mirror" --environment KDUMP_UTILS_RPM="$rpm_path" -a provision -h virtual -i "$test_image"

--- a/tools/run-integration-tests.sh
+++ b/tools/run-integration-tests.sh
@@ -15,36 +15,51 @@ for _opt in "$@"; do
 	--deployment_mode=*)
 		deployment_mode=${_opt#*=}
 		;;
+	--build_rpm=*)
+		build_rpm=${_opt#*=}
+		;;
 	*)
 		"Ignore unknown parameter $_opt"
 		;;
 	esac
 done
 
+build_local_rpm() {
+	dist_abbr=.fc$fedora_version
+
+	VERSION=$(rpmspec -q --queryformat "%{VERSION}" kdump-utils.spec)
+	SRC_ARCHIVE=kdump-utils-$VERSION.tar.gz
+	if ! git archive --format=tar.gz -o "$SRC_ARCHIVE" --prefix="kdump-utils-$VERSION/" HEAD; then
+		echo "Failed to create kdump-utils source archive"
+		exit 1
+	fi
+
+	if ! rpmbuild -ba -D "dist $dist_abbr" -D "_sourcedir $(pwd)" -D "_builddir $(pwd)" -D "_srcrpmdir $(pwd)" -D "_rpmdir $(pwd)" kdump-utils.spec; then
+		echo "Failed to build kdump-utils rpm"
+		exit 1
+	fi
+
+	arch=$(uname -m)
+	rpm_name=$(rpmspec -D "dist $dist_abbr" -q --queryformat '%{NAME}-%{VERSION}-%{RELEASE}.%{ARCH}' kdump-utils.spec)
+	rpm_path="$(pwd)/${arch}/${rpm_name}.rpm"
+	if [[ ! -f $rpm_path ]]; then
+		echo "Failed to find built kdump-utils rpm ($rpm_path doesn't eixst)"
+		return 1
+	fi
+	# cp the built rpm to tests rootdir so tmt will copy it to test env automatically
+	cp "$rpm_path" ./
+}
+
+if [[  $build_rpm == yes ]]; then
+	if build_local_rpm; then
+		KDUMP_UTILS_RPM=$(basename "$rpm_path")
+	fi
+fi
+
 [[ -z $mirror ]] && mirror=https://mirrors.tuna.tsinghua.edu.cn/fedora
 
 [[ -z $mirror ]] && [[ $fedora_version == rawhide ]] && mirror=https://mirrors.sjtug.sjtu.edu.cn/fedora/linux
 
-dist_abbr=.fc$fedora_version
-
-VERSION=$(rpmspec -q --queryformat "%{VERSION}" kdump-utils.spec)
-SRC_ARCHIVE=kdump-utils-$VERSION.tar.gz
-if ! git archive --format=tar.gz -o "$SRC_ARCHIVE" --prefix="kdump-utils-$VERSION/" HEAD; then
-	echo "Failed to create kdump-utils source archive"
-	exit 1
-fi
-
-if ! rpmbuild -ba -D "dist $dist_abbr" -D "_sourcedir $(pwd)" -D "_builddir $(pwd)" -D "_srcrpmdir $(pwd)" -D "_rpmdir $(pwd)" kdump-utils.spec; then
-	echo "Failed to build kdump-utils rpm"
-	exit 1
-fi
-
-arch=$(uname -m)
-rpm_name=$(rpmspec -D "dist $dist_abbr" -q --queryformat '%{NAME}-%{VERSION}-%{RELEASE}.%{ARCH}' kdump-utils.spec)
-rpm_path="$(pwd)/${arch}/${rpm_name}.rpm"
-if [[ ! -f $rpm_path ]]; then
-	echo "Failed to find built kdump-utils rpm ($rpm_path doesn't eixst)"
-fi
 [[ -z $deployment_mode ]] && deployment_mode=package
 
 test_image=/var/tmp/tmt/testcloud/images/
@@ -58,4 +73,4 @@ if [[ ! -e $test_image ]]; then
 	test_image=fedora:"$fedora_version"
 fi
 
-cd tests && tmt --context distro="fedora-${fedora_version}" --context deployment_mode="$deployment_mode" run --environment COPR_REPO_URL="$COPR_REPO_URL" --environment CUSTOM_MIRROR="$mirror" --environment KDUMP_UTILS_RPM="$rpm_path" -a provision -h virtual -i "$test_image"
+cd tests && tmt --context distro="fedora-${fedora_version}" --context deployment_mode="$deployment_mode" run --environment COPR_REPO_URL="$COPR_REPO_URL" --environment CUSTOM_MIRROR="$mirror" --environment KDUMP_UTILS_RPM="$KDUMP_UTILS_RPM" -a provision -h virtual -i "$test_image"


### PR DESCRIPTION
## Summary by Sourcery

Add support for image-based deployment mode in integration tests and CI workflow

New Features:
- Introduce a new deployment mode option for integration tests, allowing tests to run in both package and image modes

Enhancements:
- Improve the run-integration-tests.sh script to support more flexible command-line arguments
- Update GitHub Actions workflow to support multiple deployment modes

Build:
- Update Packit configuration to target specific Fedora versions and architectures

CI:
- Add a new test setup script to handle RPM installation for different deployment scenarios
- Modify GitHub Actions matrix to test both package and image deployment modes