### PR TITLE
kdumpctl: improve do_estimate by considering unpacked initramfs size

### DIFF
--- a/kdumpctl
+++ b/kdumpctl
@@ -1259,12 +1259,48 @@ get_kernel_size()
 	echo $_size
 }
 
+get_unpacked_initramfs_size()
+{
+	local _tmp_unpack_dir="$KDUMP_TMPDIR/initrd_unpack"
+	local _size
+	mkdir -p "$_tmp_unpack_dir"
+
+	(cd "$_tmp_unpack_dir" && lsinitrd "$TARGET_INITRD" --unpack >/dev/null 2>&1)
+
+	# Add size of any squashfs/erofs images after unpacking/mounting
+	while read -r _img; do
+		local _img_mnt="$_tmp_unpack_dir/img_$$"
+		local _img_fs="squashfs"
+		mkdir -p "$_img_mnt"
+
+		if [[ "$_img" == *"erofs-root.img" ]]; then
+			_img_fs="erofs"
+			# lsinitrd use fsck.erofs to extract erofs-root.img.
+			if [[ -e "$_tmp_unpack_dir/erofs-root" ]]; then
+				_size=$(du -sb "$_tmp_unpack_dir/erofs-root" | awk '{print $1}')
+			fi
+			if [[ "$_size" -ne 0 ]]; then
+				break
+			fi
+		fi
+
+		if mount -t "$_img_fs" "$_img" "$_img_mnt" 2>/dev/null; then
+			_size=$(du -sb "$_img_mnt" | awk '{print $1}')
+			umount "$_img_mnt"
+		else
+			derror "mount -t $_img_fs $_img failed!"
+		fi
+	done < <(find "$_tmp_unpack_dir" -name "*.img")
+	echo "$_size"
+}
+
 do_estimate()
 {
 	local kdump_mods
 	local -A large_mods
 	local baseline
 	local kernel_size mod_size initrd_size baseline_size runtime_size reserved_size estimated_size recommended_size _cryptsetup_overhead
+	local unpacked_initramfs_size
 	local size_mb=$((1024 * 1024))
 
 	setup_initrd
@@ -1296,12 +1332,15 @@ do_estimate()
 	# Current reserved crashkernel size
 	reserved_size=$(get_reserved_mem_size)
 	# A pre-estimated value for userspace usage and kernel
-	# runtime allocation, 64M should good for most cases
-	runtime_size=$((64 * size_mb))
+	# runtime allocation, 32M should good for most cases
+	runtime_size=$((32 * size_mb))
 	# Kernel image size
 	kernel_size=$(get_kernel_size "$KDUMP_KERNEL")
 	# Kdump initramfs size
 	initrd_size=$(du -b "$TARGET_INITRD" | awk '{print $1}')
+	# Get the decompressed size of initramfs contents
+	unpacked_initramfs_size=$(get_unpacked_initramfs_size)
+
 	# Kernel modules static size after loaded
 	mod_size=0
 	while read -r _name _size _; do
@@ -1338,7 +1377,7 @@ do_estimate()
 		echo -e "Encrypted kdump target requires extra memory, assuming using the keyslot with maximum memory requirement\n"
 	fi
 
-	estimated_size=$((kernel_size + mod_size + initrd_size + runtime_size + crypt_size))
+	estimated_size=$((kernel_size + mod_size + unpacked_initramfs_size + initrd_size + runtime_size + crypt_size))
 	if [[ $baseline_size -gt $estimated_size ]]; then
 		recommended_size=$baseline_size
 	else
@@ -1351,6 +1390,7 @@ do_estimate()
 	echo "Kernel image size:   $((kernel_size / size_mb))M"
 	echo "Kernel modules size: $((mod_size / size_mb))M"
 	echo "Initramfs size:      $((initrd_size / size_mb))M"
+	echo "Unpacked initramfs size: $((unpacked_initramfs_size / size_mb))M"
 	echo "Runtime reservation: $((runtime_size / size_mb))M"
 	[[ $crypt_size -ne 0 ]] &&
 		echo "LUKS required size:  $((crypt_size / size_mb))M"

--- a/kdumpctl
+++ b/kdumpctl
@@ -1288,7 +1288,7 @@ do_estimate()
 	elif [[ ${baseline: -1} == "G" ]]; then
 		baseline=$((${baseline%G} * 1024))
 	elif [[ ${baseline: -1} == "T" ]]; then
-		baseline=$((${baseline%Y} * 1048576))
+		baseline=$((${baseline%T} * 1048576))
 	fi
 
 	# The default pre-reserved crashkernel value


### PR DESCRIPTION
### **User description**
A memory peak in kdump occurs when the initramfs is being decompressed. At this
moment, both the compressed and decompressed initramfs coexist in memory. After
this, the compressed initramfs is released.

This patch enhances the do_estimate function in kdumpctl by incorporating
the size of the unpacked initramfs contents into the crashkernel memory
estimation. The following changes have been made:

Added logic to extract and measure the size of the unpacked initramfs,
including any squashfs/erofs images.
Adjusted the default runtime reservation from 64M to 32M to better reflect
typical use cases.
Updated output to display the unpacked initramfs size.
These improvements help ensure a more accurate memory reservation for kdump
environments.

Signed-off-by: Lichen Liu [lichliu@redhat.com](mailto:lichliu@redhat.com)


___

### **PR Type**
Enhancement, Tests


___

### **Description**
- Enhance crashkernel estimation by including unpacked initramfs size
  - Add function to extract and measure unpacked initramfs (including squashfs/erofs)
  - Update estimation logic to use unpacked initramfs size
  - Display unpacked initramfs size in output

- Adjust default runtime reservation from 64M to 32M

- Fix typo in crashkernel baseline size calculation for terabytes

- Update memory rounding logic in `get_system_size` and corresponding tests


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>kdumpctl</strong><dd><code>Enhance crashkernel estimation with unpacked initramfs size</code></dd></summary>
<hr>

kdumpctl

<li>Add <code>get_unpacked_initramfs_size</code> to extract and measure unpacked <br>initramfs<br> <li> Update <code>do_estimate</code> to use unpacked initramfs size in calculations<br> <li> Fix typo in baseline size calculation for terabytes<br> <li> Lower default runtime reservation from 64M to 32M<br> <li> Print unpacked initramfs size in estimation output


</details>


  </td>
  <td><a href="https://github.com/coiby/kdump-utils/pull/16/files#diff-03a781ca2c9b1db0905a613a6d931f6fb0bde0803a2ccbe53042702246aa9a2e">+44/-4</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>kdump-lib.sh</strong><dd><code>Align system memory calculation with kernel logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

kdump-lib.sh

<li>Round up total memory to nearest 128M in <code>get_system_size</code><br> <li> Align memory calculation with kernel's crash reserve logic


</details>


  </td>
  <td><a href="https://github.com/coiby/kdump-utils/pull/16/files#diff-b31a5837a63c042a38ac277903c137ebcd0c84560906acd84eb4ee77319c7d72">+5/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>kdump-lib_spec.sh</strong><dd><code>Update tests for memory rounding in get_system_size</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

spec/kdump-lib_spec.sh

<li>Update tests for <code>get_system_size</code> to reflect new rounding logic<br> <li> Use 1000MB blocks and verify correct rounding to GB


</details>


  </td>
  <td><a href="https://github.com/coiby/kdump-utils/pull/16/files#diff-681f73d40eb15c64b168f2498f990071f4d0fcc5eb3380050dc1b782b47799af">+7/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>