### PR TITLE
mkdumprd: mount the root partition when FIPS is enabled with no boot partition

### DIFF
--- a/mkdumprd
+++ b/mkdumprd
@@ -433,7 +433,7 @@ if ! is_fadump_capable; then
 	# If /boot is not on a separate partition, the fips dracut module will
 	# link /sysroot/boot to /boot. So we need to mount the root partition
 	# to /sysroot beforehand.
-	if [[ $(cat /proc/sys/crypto/fips_enabled) == 1  ]]; then
+	if [[ $(cat /proc/sys/crypto/fips_enabled 2> /dev/null) == 1  ]]; then
 		_boot_source=$(findmnt -n -o SOURCE --target /boot)
 		if mountpoint -q /boot; then
 			dracut_args+=(--add-device "$_boot_source")

--- a/mkdumprd
+++ b/mkdumprd
@@ -424,8 +424,22 @@ if ! is_fadump_capable; then
 
 	dracut_args+=(--no-hostonly-default-device)
 
+	# When FIPS mode is enabled, the fips dracut module needs to use
+	# /boot/.vmlinuz-${KERNEL}.hmac to verify the integrity of the kernel.
+	#
+	# If /boot is on a separate partition, the fips module will mount /boot
+	# based on the boot= kernel parameter.
+	#
+	# If /boot is not on a separate partition, the fips dracut module will
+	# link /sysroot/boot to /boot. So we need to mount the root partition
+	# to /sysroot beforehand.
 	if [[ $(cat /proc/sys/crypto/fips_enabled) == 1  ]]; then
-		dracut_args+=(--add-device "$(findmnt -n -o SOURCE --target /boot)")
+		_boot_source=$(findmnt -n -o SOURCE --target /boot)
+		if mountpoint -q /boot; then
+			dracut_args+=(--add-device "$_boot_source")
+		else
+			add_mount "$_boot_source"
+		fi
 	fi
 fi
 

--- a/spec/kdump-lib_spec.sh
+++ b/spec/kdump-lib_spec.sh
@@ -120,4 +120,17 @@ Describe 'kdump-lib'
 		End
 	End
 
+	Describe "get_kdump_mntpoint_from_target"
+		get_mntpoint_from_target() {
+			echo -n "/"
+		}
+
+
+		# the fips dracut module requires this when there is no boot partition
+		It 'should make sure root partition will be mounted to /sysroot'
+			When call get_kdump_mntpoint_from_target "/dev/vda2"
+			The output should equal "/sysroot"
+		End
+	End
+
 End


### PR DESCRIPTION
### **User description**
Currently, remote vmcore dumping fails when FIPS mode is enabled on a
system with no boot partition,

    [    3.440880] systemd[1]: Starting dracut-pre-pivot.service - dracut pre-pivot and cleanup hook...
    ...
    [    3.461906] dracut-pre-pivot[627]: fips-noboot: start
    [    3.638070] dracut: FATAL: You have to specify boot=<boot device> as a boot option for fips=1
    [    3.639323] dracut: Refusing to continue
    ...
    [    3.475819] systemd[1]: Poweroff requested from client PID 649 ('systemctl') (unit dracut-pre-pivot.service)...
    [    3.477611] systemd[1]: Shutting down.
    ...
    [    3.914537] systemd-shutdown[1]: Powering off.
    [    3.916464] ACPI: PM: Preparing to enter system sleep state S5
    [    3.917614] reboot: Power down

This happens because the fips dracut module shutdowns the system when it
can't find /sysroot/boot. So mount the root partition to /sysroot to fix
this issue.


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Fix FIPS-enabled systems without boot partition failing vmcore dump
  - Mount root partition to /sysroot if /boot is not separate
  - Ensure dracut fips module can verify kernel integrity

- Add unit test to verify root partition mounts to /sysroot


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>mkdumprd</strong><dd><code>Fix FIPS handling for systems without separate boot partition</code></dd></summary>
<hr>

mkdumprd

<li>Add logic to mount root partition to /sysroot if FIPS is enabled and <br>/boot is not a separate partition<br> <li> Ensure dracut receives correct device for kernel integrity <br>verification<br> <li> Add explanatory comments for FIPS and dracut behavior


</details>


  </td>
  <td><a href="https://github.com/coiby/kdump-utils/pull/17/files#diff-37c8bf1f7a3940c8c32ccebdf7383edf9e743d96b13bf2900757a9b94fc170c8">+15/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>kdump-lib_spec.sh</strong><dd><code>Add test for root partition mounting in FIPS mode</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

spec/kdump-lib_spec.sh

<li>Add unit test to verify root partition mounts to /sysroot for FIPS<br> <li> Mock function to simulate mount point retrieval<br> <li> Ensure test coverage for new FIPS-related logic


</details>


  </td>
  <td><a href="https://github.com/coiby/kdump-utils/pull/17/files#diff-681f73d40eb15c64b168f2498f990071f4d0fcc5eb3380050dc1b782b47799af">+13/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>