### PR TITLE
mkdumprd: replace lz4hc with lzma for better compression in squash image

### DIFF
--- a/mkdumprd
+++ b/mkdumprd
@@ -404,7 +404,7 @@ if ! have_compression_in_dracut_args; then
 		dracut_args+=(--squash-compressor zstd)
 	elif has_dracut_module squash-erofs && has_command mkfs.erofs; then
 		dracut_args+=(--add squash-erofs)
-		dracut_args+=(--squash-compressor lz4hc)
+		dracut_args+=(--squash-compressor lzma)
 	elif has_command mksquashfs; then
 		# only true for dracut <= 103
 		dracut_args+=(--add squash)


### PR DESCRIPTION
Among the compression algorithms currently enabled in RHEL-10, erofs+lzma has a higher compression ratio than lz4hc, this patch will replace it with lzma.

Testing shows when using erofs+lz4hc in RHEL-10, the size of the initramfs generated for local dump is 47M, and the size for nfs dump is 57M. After using lzma, the size is reduced to 39M and 45M. This is very closely compared to the 38M and 44M when using squashfs+zstd.

## Summary by Sourcery

Enhancements:
- Replace lz4hc with lzma as the default compressor for squash images in mkdumprd