### PR TITLE
kdumpctl: warn when reset crashkernel for low memory systems

### DIFF
--- a/kdumpctl
+++ b/kdumpctl
@@ -1500,6 +1500,23 @@ _get_all_kernels_from_grubby()
 	echo -n "$_kernels"
 }
 
+check_mem_requirement()
+{
+        local _sys_mem _min_mem _dump_mode _msg
+        _dump_mode=$1
+        _sys_mem=$(get_system_size)
+        _min_mem=2
+        _msg="No memory will be reserved for crash kernel for this system because the system memory is too low,"
+        if [[ $_dump_mode == fadump ]]; then
+                _min_mem=4
+        fi
+        if [[ $_sys_mem -lt $_min_mem ]]; then
+                _msg+=" ${_dump_mode} requires more than ${_min_mem}GB memory."
+                dwarn "$_msg"
+				return 1
+        fi
+}
+
 reset_crashkernel()
 {
 	local _opt _val _reboot _grubby_kernel_path _kernel _kernels
@@ -1599,6 +1616,7 @@ reset_crashkernel()
 			_has_changed="Updated crashkernel=$_new_ck"
 		fi
 		if [[ -n "$_has_changed" ]]; then
+			check_mem_requirement "$_dump_mode"
 			_needs_reboot=1
 			dwarn "$_has_changed for kernel=$_kernel. Please reboot the system for the change to take effect."
 		fi


### PR DESCRIPTION
### **User description**
The function of reset-crashkernel is to set crashkernel to the default value  of  kdump-utils. However,  our  current  default value does not reserve  memory  when  the  operating system memory is less than 2G or fadump  is  enabled and the memory is less than 4G. Add a warn message to  let  the user know that no memory will be reserved for crashkernel due to insufficient system memory.

This  patch  does  not  prevent kdumpctl from setting the crashkernel, because even if the crashkernel cannot be reserved, it is harmless and could be useful for systems that are used as vm templates.


___

### **PR Type**
Enhancement


___

### **Description**
• Add warning messages for low memory systems during crashkernel reset
• Inform users when insufficient memory prevents crash kernel reservation
• Support both regular kdump (2GB threshold) and fadump (4GB threshold) scenarios


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>kdumpctl</strong><dd><code>Add memory warnings in reset_crashkernel function</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

kdumpctl

• Add system memory size check using <code>get_system_size()</code><br> • Add warning <br>for fadump systems with less than 4GB memory<br> • Add warning for regular <br>systems with less than 2GB memory<br> • Declare new local variable <br><code>_sys_mem</code> for memory calculations


</details>


  </td>
  <td><a href="https://github.com/coiby/kdump-utils/pull/19/files#diff-03a781ca2c9b1db0905a613a6d931f6fb0bde0803a2ccbe53042702246aa9a2e">+7/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>