### PR TITLE
Support dumping to a LUKS-encrypted target

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,7 +19,7 @@ jobs:
       - run: dnf install shellcheck -y
       # Currently, for kdump-utils, there is need for shellcheck to require
       # the sourced file to give correct warnings about the checked file
-      - run: shellcheck -x *.sh  kdumpctl mk*dumprd
+      - run: shellcheck -x *.sh  kdumpctl mk*dumprd kdump-udev-throttler
       - run: shellcheck -x dracut/*/*.sh
       - run: shellcheck -x tests/*/*/*.sh tools/*.sh
       # disable the follow checks for unit tests

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,7 +9,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - run: dnf install shfmt -y
-      - run: shfmt -s -d *.sh kdumpctl mk*dumprd tests/*/*/*.sh dracut/*/*.sh tools/*.sh
+      - run: shfmt -s -d *.sh kdumpctl mk*dumprd kdump-udev-throttler tests/*/*/*.sh dracut/*/*.sh tools/*.sh
 
   static-analysis:
     runs-on: ubuntu-latest

--- a/dracut/99kdumpbase/kexec-crypt-setup.sh
+++ b/dracut/99kdumpbase/kexec-crypt-setup.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+#
+echo true > /sys/kernel/config/crash_dm_crypt_keys/restore

--- a/dracut/99kdumpbase/module-setup.sh
+++ b/dracut/99kdumpbase/module-setup.sh
@@ -1135,6 +1135,13 @@ $(command -v cryptsetup) luksOpen --volume-key-keyring \
 EOF
     done
 
+    # latest systemd makes /usr read-only by default
+    mkdir -p "${initdir}/etc/systemd/system.conf.d"
+    cat << EOF > "${initdir}/etc/systemd/system.conf.d/kdump_luks.conf"
+[Manager]
+ProtectSystem=false
+EOF
+
     dracut_need_initqueue
 }
 

--- a/dracut/99kdumpbase/module-setup.sh
+++ b/dracut/99kdumpbase/module-setup.sh
@@ -1094,6 +1094,50 @@ ForwardToConsole=yes
 EOF
 }
 
+kdump_check_crypt_targets() {
+    local _luks_dev _devuuid _key_desc
+    declare -a _luks_devs
+
+    mapfile -t _luks_devs < <(get_all_kdump_crypt_dev)
+
+    if [[ ${#_luks_devs[@]} -lt 1 ]]; then
+        return
+    fi
+
+    if [[ ! -d $LUKS_CONFIGFS ]]; then
+        dwarn "$LUKS_CONFIGFS not available"
+        return 1
+    fi
+
+    # This overrides behaviour of 90crypt
+    inst cryptsetup
+    instmods dm_crypt
+
+    echo > "$initdir/etc/cmdline.d/90crypt.conf"
+    echo > "$initdir/etc/crypttab"
+    echo > "${initdir}/sbin/crypt-run-generator"
+
+    # configfs is mounted after dracut pre-udev hook
+    # shellcheck disable=SC2154
+    inst_hook initqueue 20 "$moddir/kexec-crypt-setup.sh"
+
+    # shellcheck disable=SC2154
+    mkdir -p "$hookdir/initqueue/finished"
+
+    for _luks_dev in "${_luks_devs[@]}"; do
+        _devuuid=$(maj_min_to_uuid "$_luks_dev")
+        _key_desc=$LUKS_KEY_PRFIX$_devuuid
+        cat << EOF >> "${initdir}/etc/udev/rules.d/70-luks-kdump.rules"
+ENV{ID_FS_UUID}=="$_devuuid", \
+RUN+="/sbin/initqueue  --settled --unique --onetime --name kdump-crypt-target-%k \
+$(command -v cryptsetup) luksOpen --volume-key-keyring \
+%%user:$_key_desc \$env{DEVNAME} luks-$_devuuid"
+EOF
+    done
+
+    dracut_need_initqueue
+}
+
 install() {
     declare -A unique_netifs ovs_unique_netifs ipv4_usage ipv6_usage
     local is_nvmf
@@ -1145,6 +1189,8 @@ install() {
     kdump_check_iscsi_targets
 
     kdump_check_nvmf_target
+
+    kdump_check_crypt_targets
 
     kdump_install_systemd_conf
 

--- a/kdump-lib-initramfs.sh
+++ b/kdump-lib-initramfs.sh
@@ -11,6 +11,10 @@ KDUMP_CONFIG_FILE="/etc/kdump.conf"
 FENCE_KDUMP_SEND="/usr/libexec/fence_kdump_send"
 # shellcheck disable=SC2034
 LVM_CONF="/etc/lvm/lvm.conf"
+# shellcheck disable=SC2034
+LUKS_CONFIGFS=/sys/kernel/config/crash_dm_crypt_keys
+# shellcheck disable=SC2034
+LUKS_KEY_PRFIX="systemd-cryptsetup:vk-"
 
 # Read kdump config in well formated style
 kdump_read_conf()

--- a/kdump-lib.sh
+++ b/kdump-lib.sh
@@ -1093,6 +1093,11 @@ get_luks_crypt_dev()
 	done
 }
 
+maj_min_to_uuid()
+{
+	lsblk -no uuid,MAJ:MIN | awk -v dev="$1" 'NF==2 && $2 == dev {print $1}'
+}
+
 # kdump_get_maj_min <device>
 # Prints the major and minor of a device node.
 # Example:

--- a/kdump-udev-throttler
+++ b/kdump-udev-throttler
@@ -26,15 +26,14 @@ unuse_luks_keys()
 
 	[[ -f $LUKS_CONFIGFS_REUSE ]] || echo 0 > $LUKS_CONFIGFS_REUSE
 }
-exec 9> $throttle_lock
-if [ $? -ne 0 ]; then
+
+if ! exec 9> $throttle_lock; then
 	echo "Failed to create the lock file! Fallback to non-throttled kdump service restart"
 	/bin/kdumpctl reload
 	exit 1
 fi
 
-flock -n 9
-if [ $? -ne 0 ]; then
+if ! flock -n 9; then
 	echo "Throttling kdump restart for concurrent udev event"
 	exit 0
 fi

--- a/kdump-udev-throttler
+++ b/kdump-udev-throttler
@@ -15,17 +15,17 @@
 
 throttle_lock="/var/lock/kdump-udev-throttle"
 
-exec 9>$throttle_lock
+exec 9> $throttle_lock
 if [ $? -ne 0 ]; then
-        echo "Failed to create the lock file! Fallback to non-throttled kdump service restart"
-        /bin/kdumpctl reload
-        exit 1
+	echo "Failed to create the lock file! Fallback to non-throttled kdump service restart"
+	/bin/kdumpctl reload
+	exit 1
 fi
 
 flock -n 9
 if [ $? -ne 0 ]; then
-        echo "Throttling kdump restart for concurrent udev event"
-        exit 0
+	echo "Throttling kdump restart for concurrent udev event"
+	exit 0
 fi
 
 # Wait for at least 1 second, at most 4 seconds for udev to settle

--- a/kdump-udev-throttler
+++ b/kdump-udev-throttler
@@ -15,6 +15,17 @@
 
 throttle_lock="/var/lock/kdump-udev-throttle"
 
+LUKS_CONFIGFS_REUSE=/sys/kernel/config/crash_dm_crypt_keys/reuse
+reuse_luks_keys()
+{
+	[[ -f $LUKS_CONFIGFS_REUSE ]] || echo 1 > $LUKS_CONFIGFS_REUSE
+}
+
+unuse_luks_keys()
+{
+
+	[[ -f $LUKS_CONFIGFS_REUSE ]] || echo 0 > $LUKS_CONFIGFS_REUSE
+}
 exec 9> $throttle_lock
 if [ $? -ne 0 ]; then
 	echo "Failed to create the lock file! Fallback to non-throttled kdump service restart"
@@ -37,6 +48,8 @@ sleep 1 && udevadm settle --timeout 3
 # holding two locks at the same time and we might miss some events
 exec 9>&-
 
+reuse_luks_keys
 /bin/kdumpctl reload
+unuse_luks_keys
 
 exit 0

--- a/kdumpctl
+++ b/kdumpctl
@@ -1115,6 +1115,9 @@ prepare_luks()
 		return 1
 	fi
 
+	# For the case of CPU/memory hotplugging, we can reuse loaded keys
+	[[ $(cat $LUKS_CONFIGFS/reuse) == 1 ]] && return 0
+
 	for _luks_dev in "${_luks_devs[@]}"; do
 		_devuuid=$(maj_min_to_uuid "$_luks_dev")
 		_key_dir=$LUKS_CONFIGFS/$_devuuid

--- a/kdumpctl
+++ b/kdumpctl
@@ -1066,9 +1066,42 @@ check_final_action_config()
 	esac
 }
 
+_get_luks_key_by_unlock()
+{
+	local _devuuid=$1 _key_des=$2
+	local _max_retries
+	local _attempt=1
+
+	local _luks_unlock_cmd=""
+
+	# Check if stdin is a terminal.
+	if [ -t 0 ]; then
+		_max_retries=5
+		ddebug "Attempting to unlock LUKS device. You have $_max_retries attempts."
+	else
+		# Not a terminal (e.g., running as system service), so only try once
+		# for cases where volume key is sealed to TPM which doesn't need user
+		# interaction.
+		_max_retries=1
+		ddebug "Attempting to unlock LUKS device (non-interactive mode)..."
+	fi
+
+	while [ "$_attempt" -le "$_max_retries" ]; do
+		if cryptsetup open "UUID=$_devuuid" DUMMY "--link-vk-to-keyring=@u::%logon:$_key_des" --test-passphrase; then
+			ddebug "Success: LUKS device unlocked."
+			dwarn "To avoid manually running kdumpctl, ensure the link-volume-key=@u::%logon:$_key_des option is correctly set up in /etc/crypttab (see man crypttab)."
+			return 0
+		fi
+		_attempt=$((_attempt + 1))
+	done
+
+	derror "Error: Could not unlock the LUKS device."
+	return 1
+}
+
 prepare_luks()
 {
-	local _luks_dev _key_id _key_des
+	local _luks_dev _key_id _key_des _luks_unlock_cmd
 	declare -a _luks_devs
 
 	mapfile -t _luks_devs < <(get_all_kdump_crypt_dev)
@@ -1087,12 +1120,19 @@ prepare_luks()
 		_key_dir=$LUKS_CONFIGFS/$_devuuid
 		_key_des=$LUKS_KEY_PRFIX$_devuuid
 		if _key_id=$(keyctl request logon "$_key_des" 2> /dev/null); then
-			mkdir "$_key_dir"
-			printf "%s" "$_key_des" > "$_key_dir"/description
+			ddebug "Succesfully get @u::%logon:$_key_des"
+		elif _get_luks_key_by_unlock "$_devuuid" "$_key_des"; then
+			_key_id=$(keyctl request logon "$_key_des")
+			ddebug "Succesfully get @u::%logon:$_key_des after cryptsetup"
 		else
-			derror "Failed to get logon key $_key_des. Ensure the link-volume-key option is correctly set up in /etc/crypttab (see man crypttab) and that the key is available."
+			derror "Failed to get logon key $_key_des. Run 'kdumpctl restart' manually to start kdump."
 			return 1
 		fi
+
+		# Let the key expire after 300 seconds
+		keyctl timeout "$_key_id" 300
+		mkdir "$_key_dir"
+		printf "%s" "$_key_des" > "$_key_dir"/description
 	done
 }
 

--- a/kdumpctl
+++ b/kdumpctl
@@ -52,6 +52,7 @@ trap '
     ret=$?;
     is_mounted $TMPMNT && umount -f $TMPMNT;
     rm -rf "$KDUMP_TMPDIR"
+    [[ -d $LUKS_CONFIGFS ]] && find $LUKS_CONFIGFS/ -mindepth 1 -type d -delete
     exit $ret;
     ' EXIT
 
@@ -741,6 +742,11 @@ load_kdump()
 	args+=("--initrd=$TARGET_INITRD")
 	args+=("$KDUMP_KERNEL")
 
+	if ! prepare_luks; then
+		derror "kexec: failed to prepare for a LUKS target"
+		return 1
+	fi
+
 	ddebug "$KEXEC ${args[*]}"
 	if $KEXEC "${args[@]}"; then
 		dinfo "kexec: loaded kdump kernel"
@@ -1058,6 +1064,36 @@ check_final_action_config()
 		return 1
 		;;
 	esac
+}
+
+prepare_luks()
+{
+	local _luks_dev _key_id _key_des
+	declare -a _luks_devs
+
+	mapfile -t _luks_devs < <(get_all_kdump_crypt_dev)
+
+	if [[ ${#_luks_devs[@]} -lt 1 ]]; then
+		return
+	fi
+
+	if [[ ! -d $LUKS_CONFIGFS ]]; then
+		dwarn "$LUKS_CONFIGFS not available, please use a newer kernel."
+		return 1
+	fi
+
+	for _luks_dev in "${_luks_devs[@]}"; do
+		_devuuid=$(maj_min_to_uuid "$_luks_dev")
+		_key_dir=$LUKS_CONFIGFS/$_devuuid
+		_key_des=$LUKS_KEY_PRFIX$_devuuid
+		if _key_id=$(keyctl request logon "$_key_des" 2> /dev/null); then
+			mkdir "$_key_dir"
+			printf "%s" "$_key_des" > "$_key_dir"/description
+		else
+			derror "Failed to get logon key $_key_des. Ensure the link-volume-key option is correctly set up in /etc/crypttab (see man crypttab) and that the key is available."
+			return 1
+		fi
+	done
 }
 
 start()

--- a/mkdumprd
+++ b/mkdumprd
@@ -318,21 +318,6 @@ handle_default_dump_target()
 	check_size fs "$_target"
 }
 
-check_crypt()
-{
-	local _dev
-
-	for _dev in $(get_kdump_targets); do
-		if [[ -n $(get_luks_crypt_dev "$(get_maj_min "$_dev")") ]]; then
-			derror "Device $_dev is encrypted." && return 1
-		fi
-	done
-}
-
-if ! check_crypt; then
-	dwarn "Warning: Encrypted device is in dump path, which is not recommended, see kexec-kdump-howto.txt for more details."
-fi
-
 # firstly get right SSH_KEY_LOCATION
 keyfile=$(kdump_get_conf_val sshkey)
 if [[ -f $keyfile ]]; then

--- a/supported-kdump-targets.txt
+++ b/supported-kdump-targets.txt
@@ -49,6 +49,7 @@ storage:
         NVMe-FC (qla2xxx, lpfc)
         NVMe/TCP configured by NVMe Boot Firmware Table (users may need to
             increase the crashkernel value)
+        LUKS-encrypted volume
 
 network:
         Hardware using kernel modules: (igb, ixgbe, ice, i40e, e1000e, igc,


### PR DESCRIPTION
### **User description**
Based on the new kernel feature that dm-crypt keys can persist for the
kdump kernel [1], this patch which is adapted from [2]
1) ask the 1st kernel to save a copy of the LUKS volume keys
2) ask the kdump kernel to add the copy of the LUKS volume keys to
   specified keyring and then use --volume-key-keyring the unlock the
   LUKS device.

[1] https://github.com/coiby/linux/blob/dm_crypt_v15/Documentation/ABI/testing/crash_dm_crypt_keys
[2] https://lists.fedorahosted.org/archives/list/kexec@lists.fedoraproject.org/message/Y3KUSJQPN3JHUUC2FPIK7H4HTSX2TUCX/


___

### **PR Type**
Enhancement


___

### **Description**
• Add LUKS encryption support for kdump targets
• Fix network interface detection for NVMe TCP targets
• Add UUID lookup utility function
• Remove deprecated encryption check warnings


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>kexec-crypt-setup.sh</strong><dd><code>Add LUKS key restoration script</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

dracut/99kdumpbase/kexec-crypt-setup.sh

• Create new script to enable dm-crypt key restoration via configfs


</details>


  </td>
  <td><a href="https://github.com/coiby/kdump-utils/pull/20/files#diff-8a55c2a18fec1eef90b84652c5067abc0dcc7bacd2d48f6b2e55ada4229e85d3">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>module-setup.sh</strong><dd><code>Add LUKS support and fix network detection</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

dracut/99kdumpbase/module-setup.sh

• Fix network interface array handling to prevent empty string returns<br> <br>• Add comprehensive LUKS target detection and setup functionality<br> • <br>Install cryptsetup tools and configure udev rules for encrypted <br>devices<br> • Override default crypt behavior with custom kdump <br>implementation


</details>


  </td>
  <td><a href="https://github.com/coiby/kdump-utils/pull/20/files#diff-ee155d1ee2beb1a151fa7366f71de6c8fee5887c78f4a346d0b5e4c505d19f5d">+54/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>kdump-lib.sh</strong><dd><code>Add device UUID lookup utility</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

kdump-lib.sh

• Add <code>maj_min_to_uuid</code> function to convert device major:minor to UUID


</details>


  </td>
  <td><a href="https://github.com/coiby/kdump-utils/pull/20/files#diff-b31a5837a63c042a38ac277903c137ebcd0c84560906acd84eb4ee77319c7d72">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>kdumpctl</strong><dd><code>Integrate LUKS key preparation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

kdumpctl

• Add <code>prepare_luks</code> function to configure LUKS keys via configfs<br> • Call <br>LUKS preparation during kdump kernel loading


</details>


  </td>
  <td><a href="https://github.com/coiby/kdump-utils/pull/20/files#diff-03a781ca2c9b1db0905a613a6d931f6fb0bde0803a2ccbe53042702246aa9a2e">+22/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>mkdumprd</strong><dd><code>Remove deprecated encryption checks</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

mkdumprd

• Remove <code>check_crypt</code> function and related encryption warnings<br> • Remove <br>deprecated encrypted device checks


</details>


  </td>
  <td><a href="https://github.com/coiby/kdump-utils/pull/20/files#diff-37c8bf1f7a3940c8c32ccebdf7383edf9e743d96b13bf2900757a9b94fc170c8">+0/-15</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>

## Summary by Sourcery

Enable dumping to LUKS-encrypted devices by capturing and restoring volume keys via dm-crypt configfs interface; improve NVMe TCP network interface detection; add a device UUID lookup utility; and remove obsolete encryption checks.

New Features:
- Support kdump targets on LUKS-encrypted volumes by persisting and restoring dm-crypt keys across kernels
- Add a utility function to lookup device UUIDs from major:minor numbers

Bug Fixes:
- Fix network interface detection logic for NVMe TCP targets

Chores:
- Remove deprecated encryption checks and related warnings