### PR TITLE
mkdumprd: include tpm2-tss dracut module for encrypted storages

### DIFF
--- a/mkdumprd
+++ b/mkdumprd
@@ -330,6 +330,10 @@ check_crypt()
 
 if ! check_crypt; then
 	dwarn "Warning: Encrypted device is in dump path, which is not recommended, see kexec-kdump-howto.txt for more details."
+	# TPM device can be used to automatically unlock encrypted volumes
+	if has_command tpm2; then
+		dracut_args+=(--add "tpm2-tss")
+	fi
 fi
 
 # firstly get right SSH_KEY_LOCATION


### PR DESCRIPTION
LUKS volumes can be automatically unlocked by TPM devices and this comes handy for kdump as there's no need to a manual action. This, however, doesn't work by default:

 systemd-cryptsetup[494]: Automatically discovered security TPM2 token unlocks volume.
 systemd-cryptsetup[494]: Could not find TPM2 device: Operation not supported
 systemd-cryptsetup[494]: TPM2 operation failed, falling back to traditional unlocking: Operation not supported

The problem is that we need to have libcryptsetup-token-systemd-tpm2.so and the corresponding tools/libraries in the initramfs and this is done by 'tpm2-tss' module which is not in the default set. Include it when 'tpm2' tool (tpm2-tools package) is present.

In theory, we can be smarter and try to detect 'systemd-tpm2' tokens with cryptsetup:

 # cryptsetup luksDump /dev/vda2
 LUKS header information
 Version:       	2
 Epoch:         	394
 ...

 Tokens:
   1: systemd-tpm2
 	tpm2-hash-pcrs:   7
 	tpm2-pcr-bank:    sha256

but the risk is that tokens can change after kdump initramfs is created. For now, stick to a simpler but more robust solution.

## Summary by Sourcery

New Features:
- Detect the tpm2 command and add the tpm2-tss module to the initramfs for TPM2-based LUKS unlocking.