### PR TITLE
Maximize the reserved size in osbuild case

### DIFF
--- a/kdump-lib.sh
+++ b/kdump-lib.sh
@@ -11,6 +11,7 @@ fi
 FADUMP_ENABLED_SYS_NODE="/sys/kernel/fadump/enabled"
 FADUMP_REGISTER_SYS_NODE="/sys/kernel/fadump/registered"
 FADUMP_APPEND_ARGS_SYS_NODE="/sys/kernel/fadump/bootargs_append"
+maximize_crashkernel=0
 
 is_uki()
 {
@@ -41,7 +42,7 @@ is_aws_aarch64()
 
 is_sme_or_sev_active()
 {
-	journalctl -q --dmesg --grep "^Memory Encryption Features active: AMD (SME|SEV)$" >/dev/null 2>&1
+	$maximize_crashkernel || journalctl -q --dmesg --grep "^Memory Encryption Features active: AMD (SME|SEV)$" >/dev/null 2>&1
 }
 
 has_command()
@@ -846,12 +847,18 @@ get_recommend_size()
 
 has_mlx5()
 {
-	[[ -d /sys/bus/pci/drivers/mlx5_core ]]
+	$maximize_crashkernel || [[ -d /sys/bus/pci/drivers/mlx5_core ]]
 }
 
 has_aarch64_smmu()
 {
-	ls /sys/devices/platform/arm-smmu-* 1> /dev/null 2>&1
+	$maximize_crashkernel || ls /sys/devices/platform/arm-smmu-* 1> /dev/null 2>&1
+}
+
+is_aarch64_64k_kernel()
+{
+	local _kernel="$1"
+	$maximize_crashkernel || echo "$_kernel" | grep -q 64k
 }
 
 is_memsize() { [[ "$1" =~ ^[+-]?[0-9]+[KkMmGgTtPbEe]?$ ]]; }
@@ -995,6 +1002,9 @@ kdump_get_arch_recommend_crashkernel()
 	local _arch _ck_cmdline _dump_mode
 	local _delta=0
 
+	# osbuild deploies rpm on chroot environment. kdump-utils has no opportunity
+	# to deduce the exact memory cost on the real target.
+	maximize_crashkernel=$(is_ostree)
 	if [[ -z "$1" ]]; then
 		if is_fadump_capable; then
 			_dump_mode=fadump
@@ -1022,7 +1032,7 @@ kdump_get_arch_recommend_crashkernel()
 		fi
 
 		# the naming convention of 64k variant suffixes with +64k, e.g. "vmlinuz-5.14.0-312.el9.aarch64+64k"
-		if echo "$_running_kernel" | grep -q 64k; then
+		if is_aarch64_64k_kernel "$_running_kernel"; then
 			# Without smmu, the diff of MemFree between 4K and 64K measured on a high end aarch64 machine is 82M.
 			# Picking up 100M to cover this diff. And finally, we have "2G-4G:356M;4G-64G:420M;64G-:676M"
 			((_delta += 100))

--- a/kdumpctl
+++ b/kdumpctl
@@ -1051,6 +1051,83 @@ check_final_action_config()
 	esac
 }
 
+get_recommend_crashkernel_value()
+{
+	local _crashkernel_str=$1
+	local _total_mem_kib
+	local _total_mem
+
+	_total_mem_kib=$(grep MemTotal /proc/meminfo | awk '{print $2}')
+	_total_mem=$((_total_mem_kib * 1024))
+
+	# Main loop
+	IFS=',' read -ra entries <<< "$_crashkernel_str"
+	for entry in "${entries[@]}"; do
+		IFS=':' read -r range size <<< "$entry"
+		# Parse range
+		if [[ $range == *-* ]]; then
+			IFS='-' read -r lower upper <<< "$range"
+			lower_bytes=$(to_bytes "$lower")
+			if [[ -z "$upper" ]]; then
+				upper_bytes=$(to_bytes 10T)  # for open-ended range (e.g., 2G-)
+			else
+				upper_bytes=$(to_bytes "$upper")
+			fi
+			if (( _total_mem >= lower_bytes && _total_mem < upper_bytes )); then
+				echo "$size"
+				return
+			fi
+		fi
+	done
+}
+
+get_crashkernel_low_value()
+{
+	mapfile -t lines < <(grep -n "Crash kernel" /proc/iomem)
+
+	if [ ${#lines[@]} -eq 1 ]; then
+		return 0
+	fi
+
+	first_line=$(grep "Crash kernel" /proc/iomem | sed -n '1p')
+	# Extract start and end addresses
+	start_hex=$(echo "$first_line" | awk '{split($1, a, "-"); print a[1]}')
+	end_hex=$(echo "$first_line" | awk '{split($1, a, "-"); print a[2]}')
+	# Convert hex to decimal
+	start_dec=$((0x$start_hex))
+	end_dec=$((0x$end_hex))
+	# Calculate size in bytes
+	size_bytes=$((end_dec - start_dec + 1))
+	echo "$size_bytes"
+}
+
+suggest_crashkernel_reset()
+{
+	local _crashkernel
+	local _recommend
+	local _recommend_value
+	local _actual_value
+
+	_crashkernel=$(sed -n 's/.*crashkernel=\([^ ]*\).*/\1/p' /proc/cmdline)
+	[[ $(kdump_get_conf_val auto_reset_crashkernel) == no ]] && return
+
+	if ! echo "$_crashkernel" | grep -q -E "(fadump|fadump=0)"; then
+		_recommend=$(kdump_get_arch_recommend_crashkernel "kdump")
+		_recommend_value=$(get_recommend_crashkernel_value "$_recommend")
+		_low_mem=$(get_crashkernel_low_value)
+		# The crashkernel formula does not include the crashkernel low value
+		# but the kexec_crash_size does.
+		_recommend_value=$(memsize_add "$_recommend_value" "$_low_mem")
+		_recommend_value=$(to_bytes "$_recommend_value")
+		_actual_value=$(cat /sys/kernel/kexec_crash_size)
+
+		if [ "$_recommend_value" -lt "$_actual_value" ]; then
+			dwarn "The reserved crashkernel is abundant. Using 'kdumpctl reset-crashkernel' to reset kernel cmdline. It will take effect in the next boot"
+			dwarn "To release the abundant memory immediately. You can do: 'kdumpctl stop', 'echo $_recommend_value >/sys/kernel/kexec_crash_size', and finally 'kdump start'"
+		fi
+	fi
+}
+
 start()
 {
 	check_dump_feasibility || return
@@ -1084,6 +1161,7 @@ start()
 	start_dump || return
 
 	dinfo "Starting kdump: [OK]"
+	suggest_crashkernel_reset
 	return 0
 }
 


### PR DESCRIPTION
At present, the deduction of the proper crashkernel value depends on
detecting platform details. However, more and more platforms are now
deployed using OSTree images, which means kdump-utils cannot retrieve
complete platform information. This often leads to an underestimation of
the memory required by the kdump kernel, increasing the risk of
out-of-memory (OOM) issues.

To mitigate this situation, we choose to maximize the reserved
crashkernel size in the osbuild case, and recommend users to update the
kernel command line and release the excess reserved memory after reboot.

That is done by: kdumpctl stop; echo $_recommend_value >/sys/kernel/kexec_crash_size; kdumpctl start

## Summary by Sourcery

Maximize reserved crashkernel memory for OSTree deployments and bypass platform memory checks accordingly.

New Features:
- Automatically maximize the reserved crashkernel size when an OSTree deployment is detected.

Enhancements:
- Introduce a maximize_crashkernel flag to skip detailed platform memory feature detections in OSTree cases.
- Add is_aarch64_64k_kernel helper to detect 64k-page-size kernels.

Tests:
- Add a spec test to ensure the root partition is mounted to /sysroot for kdump target mntpoint determination.