### PR TITLE
Luks fix2

### DIFF
--- a/kdump.service
+++ b/kdump.service
@@ -11,6 +11,7 @@ ExecStop=/usr/bin/kdumpctl stop
 ExecReload=/usr/bin/kdumpctl reload
 RemainAfterExit=yes
 StartLimitInterval=0
+KeyringMode=shared
 
 [Install]
 WantedBy=multi-user.target

--- a/kdumpctl
+++ b/kdumpctl
@@ -1316,6 +1316,7 @@ setup_crypttab()
 		return 0
 	else
 		mv "$temp_file" "$CRYPTTAB_FILE"
+		restorecon "$CRYPTTAB_FILE"
 		dinfo "Success! $CRYPTTAB_FILE has been updated."
 
 		# Parse status updates and report on each changed UUID

--- a/kdumpctl
+++ b/kdumpctl
@@ -737,7 +737,8 @@ function load_kdump_kernel_key()
 	if ! [[ -f /proc/device-tree/ibm,secure-boot ]]; then
 		return
 	fi
-
+	# %.ima keyring is writable to the user, no need to use
+	# "sudo -i keyctl"
 	keyctl padd asymmetric "" %:.ima < "/usr/share/doc/kernel-keys/$KDUMP_KERNELVER/kernel-signing-ppc.cer"
 }
 
@@ -760,6 +761,7 @@ load_kdump()
 		return 1
 	fi
 
+	[[ ${KEYCTL_CMD[0]} == sudo ]] && KEXEC="sudo -i $KEXEC"
 	ddebug "$KEXEC ${args[*]}"
 	if $KEXEC "${args[@]}"; then
 		dinfo "kexec: loaded kdump kernel"
@@ -1084,6 +1086,9 @@ remove_luks_vol_keys()
 	local _key_line _key_id _key_desc _status=1
 
 	# Get all keys from @u keyring and process each line
+	# sudo process by default only has the permission to list the keys
+	# stored in user keyring i.e. "sudo keyctl list" can work not
+	# "sudo keyctl unlink/show"
 	while read -r _key_line; do
 		# Skip header lines and empty lines
 		[[ $_key_line =~ ^[0-9]+: ]] || continue
@@ -1100,7 +1105,7 @@ remove_luks_vol_keys()
 
 		# Check if key description starts with LUKS_KEY_PRFIX
 		if [[ $_key_desc == "$LUKS_KEY_PRFIX"* ]]; then
-			keyctl unlink "$_key_id"
+			"${KEYCTL_CMD[@]}" unlink "$_key_id"
 			_status=0
 		fi
 	done < <(keyctl list @u 2> /dev/null || true)
@@ -1142,10 +1147,21 @@ _get_luks_key_by_unlock()
 	return 1
 }
 
+# Some users may use "sudo kdumpctl". sudo process by default inherits the
+# session keyring (@s) of the original user which means it can't read LUKS keys
+# stored in root's user (@u) which is only linked to root's session keyring.
+# So use "sudo -i keyctl" and "sudo kexec" automatically in order to be able to
+# search and read the LUKS key(s).
+KEYCTL_CMD=(keyctl)
 prepare_luks()
 {
 	local _key_id _key_des _luks_unlock_cmd
 	declare -a _luks_devs
+
+	# Use "sudo -i" to use the root's session keyring to access LUKS keys
+	if ! keyctl show @s | grep -qs "_uid.0$"; then
+		KEYCTL_CMD=(sudo -i keyctl)
+	fi
 
 	mapfile -t _luks_devs < <(get_all_kdump_crypt_dev)
 
@@ -1174,10 +1190,13 @@ prepare_luks()
 	for _devuuid in "${_luks_devs[@]}"; do
 		_key_dir=$LUKS_CONFIGFS/$_devuuid
 		_key_des=$LUKS_KEY_PRFIX$_devuuid
-		if _key_id=$(keyctl request logon "$_key_des" 2> /dev/null); then
+		if _key_id=$("${KEYCTL_CMD[@]}" request logon "$_key_des" 2> /dev/null); then
 			ddebug "Succesfully get @u::%logon:$_key_des"
 		elif _get_luks_key_by_unlock "$_devuuid" "$_key_des"; then
-			_key_id=$(keyctl request logon "$_key_des")
+			if ! _key_id=$("${KEYCTL_CMD[@]}" request logon "$_key_des"); then
+				derror "Probably you are using 'sudo kdumpctl' or 'sudo su', please retry with 'sudo -i kdumpctl'"
+				return 1
+			fi
 			ddebug "Succesfully get @u::%logon:$_key_des after cryptsetup"
 		else
 			derror "Failed to get logon key $_key_des. Run 'kdumpctl restart' manually to start kdump."
@@ -1185,7 +1204,7 @@ prepare_luks()
 		fi
 
 		# Let the key expire after 300 seconds
-		keyctl timeout "$_key_id" 300
+		"${KEYCTL_CMD[@]}" timeout "$_key_id" 300
 		mkdir "$_key_dir"
 		printf "%s" "$_key_des" > "$_key_dir"/description
 	done

--- a/spec/kdumpctl_setup_crypttab_spec.sh
+++ b/spec/kdumpctl_setup_crypttab_spec.sh
@@ -5,6 +5,10 @@ Describe "kdumpctl "
 	dinfo() {
 		echo "$1"
 	}
+	restorecon() {
+		:
+	}
+
 	Describe "setup_crypttab()"
 		# Set up global variables and mocks for each test
 		# shellcheck disable=SC2016 # expand expression later


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Enable `KeyringMode=shared` in kdump.service to allow LUKS volume key access

- Restore SELinux labels on crypttab file after modifications

- Fix kdump failures with LUKS-encrypted dump targets


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["kdump.service"] -->|"Add KeyringMode=shared"| B["Root keyring accessible"]
  B -->|"Enable LUKS key access"| C["LUKS unlock succeeds"]
  D["crypttab modifications"] -->|"restorecon applied"| E["SELinux labels restored"]
  E -->|"Correct policy context"| F["Boot succeeds"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>kdump.service</strong><dd><code>Add KeyringMode=shared for LUKS key access</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

kdump.service

<ul><li>Added <code>KeyringMode=shared</code> configuration to link root's user keyring to <br>session keyring<br> <li> Enables kdump.service to access LUKS volume keys stored in root's <br>keyring<br> <li> Resolves kdump failures when attempting to unlock LUKS-encrypted dump <br>targets</ul>


</details>


  </td>
  <td><a href="https://github.com/coiby/kdump-utils/pull/26/files#diff-9696baa012326a93d54b6ba73293e9ed145a04b9b11e93a0e4a73b1caabb1f56">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>kdumpctl</strong><dd><code>Restore SELinux labels on crypttab updates</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

kdumpctl

<ul><li>Added <code>restorecon</code> call after updating crypttab file to restore SELinux <br>labels<br> <li> Prevents boot failures with older selinux-policy versions<br> <li> Ensures crypttab file has correct security context after modifications</ul>


</details>


  </td>
  <td><a href="https://github.com/coiby/kdump-utils/pull/26/files#diff-03a781ca2c9b1db0905a613a6d931f6fb0bde0803a2ccbe53042702246aa9a2e">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

