### PR TITLE
mkdumprd: basic support for btrfs subvol

### DIFF
--- a/dracut/99kdumpbase/module-setup.sh
+++ b/dracut/99kdumpbase/module-setup.sh
@@ -683,16 +683,21 @@ kdump_install_pre_post_conf() {
 }
 
 default_dump_target_install_conf() {
-    local _target _fstype
+    local _target _fstype _subvol _options
     local _mntpoint _save_path
 
     is_user_configured_dump_target && return
 
     _save_path=$(get_bind_mount_source "$(get_save_path)")
     _target=$(get_target_from_path "$_save_path")
-    _mntpoint=$(get_mntpoint_from_target "$_target")
-
+    _options=$(get_mount_info OPTIONS target "$_save_path" -f)
     _fstype=$(get_fs_type_from_target "$_target")
+    if [[ $_fstype == btrfs ]]; then
+        _subvol=$(get_btrfs_subvol_from_mntopt "$_options")
+    fi
+
+    _mntpoint=$(get_mntpoint_from_target "$_target" "$_subvol")
+
     if is_fs_type_nfs "$_fstype"; then
         kdump_collect_netif_usage "$_target"
         _fstype="nfs"

--- a/kdump-lib-initramfs.sh
+++ b/kdump-lib-initramfs.sh
@@ -110,13 +110,27 @@ get_fs_type_from_target()
 
 get_mntpoint_from_target()
 {
-	# get the first TARGET when SOURCE doesn't end with ].
-	# In most cases, a SOURCE ends with ] when fsroot or subvol exists.
-	_mntpoint=$(get_mount_info TARGET,SOURCE source "$1" | grep -v "\]$" | awk 'NR==1 { print $1 }')
-
+	_subvol="$2"
+	if [ -z "$_subvol" ]; then
+		# get the first TARGET when SOURCE doesn't end with ].
+		# In most cases, a SOURCE ends with ] when fsroot or subvol exists.
+		_mntpoint=$(get_mount_info TARGET,SOURCE source "$1" | grep -v "\]$" | awk 'NR==1 { print $1 }')
+	else
+		# btrfs with subvol
+		_mntpoint=$(get_mount_info TARGET,SOURCE source "$1" | grep "\[$_subvol\]$" | awk 'NR==1 { print $1 }')
+	fi
 	# fallback to the old way when _mntpoint is empty.
 	[ -n "$_mntpoint" ] || _mntpoint=$(get_mount_info TARGET source "$1" -f)
 	echo "$_mntpoint"
+}
+
+get_btrfs_subvol_from_mntopt()
+{
+	_subvol=${1#*subvol=}
+	# mount option may not contain subvol
+	[ "$1" != "$_subvol" ] || return 0
+	_subvol=${_subvol%%,*}
+	echo "$_subvol"
 }
 
 is_ssh_dump_target()

--- a/mkdumprd
+++ b/mkdumprd
@@ -76,10 +76,13 @@ to_mount()
 {
 	local _target=$1 _fstype=$2 _options=$3 _sed_cmd _new_mntpoint _pdev
 
-	_new_mntpoint=$(get_kdump_mntpoint_from_target "$_target")
 	_fstype="${_fstype:-$(get_fs_type_from_target "$_target")}"
 	_options="${_options:-$(get_mntopt_from_target "$_target")}"
 	_options="${_options:-defaults}"
+	if [[ $_fstype == btrfs ]]; then
+		_subvol=$(get_btrfs_subvol_from_mntopt "$_options")
+	fi
+	_new_mntpoint=$(get_kdump_mntpoint_from_target "$_target" "$_subvol")
 
 	if [[ $_fstype == "nfs"* ]]; then
 		_pdev=$_target
@@ -146,7 +149,7 @@ mkdir_save_path_ssh()
 #$1=dump target
 get_fs_size()
 {
-	df --output=avail "$(get_mntpoint_from_target "$1")/$SAVE_PATH" | tail -1
+	df --output=avail "$(get_mntpoint_from_target "$1" "$2")/$SAVE_PATH" | tail -1
 }
 
 #Function: get_raw_size
@@ -159,6 +162,7 @@ get_raw_size()
 #Function: check_size
 #$1: dump type string ('raw', 'fs', 'ssh')
 #$2: dump target
+#$3: btrfs subvol
 check_size()
 {
 	local avail memtotal
@@ -172,7 +176,7 @@ check_size()
 		avail=$(get_ssh_size "$2")
 		;;
 	fs)
-		avail=$(get_fs_size "$2")
+		avail=$(get_fs_size "$2" "$3")
 		;;
 	*)
 		return
@@ -302,20 +306,24 @@ add_mount()
 #handle the case user does not specify the dump target explicitly
 handle_default_dump_target()
 {
-	local _target
-	local _mntpoint
+	local _target _mntpoint _fstype _subvol _options
 
 	is_user_configured_dump_target && return
 
 	check_save_path_fs "$SAVE_PATH"
 
 	_save_path=$(get_bind_mount_source "$SAVE_PATH")
+	_options=$(get_mount_info OPTIONS target "$_save_path" -f)
 	_target=$(get_target_from_path "$_save_path")
-	_mntpoint=$(get_mntpoint_from_target "$_target")
+	_fstype=$(get_fs_type_from_target "$_target")
+	if [[ $_fstype == btrfs ]]; then
+		_subvol=$(get_btrfs_subvol_from_mntopt "$_options")
+	fi
 
+	_mntpoint=$(get_mntpoint_from_target "$_target" "$_subvol")
 	SAVE_PATH=${_save_path##"$_mntpoint"}
-	add_mount "$_target"
-	check_size fs "$_target"
+	add_mount "$_target" "$_fstype" "$_options"
+	check_size fs "$_target" "$_subvol"
 }
 
 # firstly get right SSH_KEY_LOCATION


### PR DESCRIPTION
### **User description**
The kdump scripts previously could not correctly handle cases where the dump target was located on a btrfs subvolume. The logic for finding the mount point did not account for the way subvolumes are represented, leading to failures in identifying the target device and checking for available space.

This patch introduces support for btrfs subvolumes by:

1.  Adding a new helper function `get_btrfs_subvol_from_mntopt` to extract the subvolume name from mount options.
2.  Modifying `get_mntpoint_from_target` to accept a subvolume name. When a subvolume is provided, it correctly identifies the mount point by looking for the source entry that includes the subvolume name (e.g., `/dev/sda1[/subvol]`).
3.  Updating various functions in `mkdumprd`, `kdump-lib.sh`, and the dracut module setup scripts to detect if the target is on a btrfs filesystem, parse the subvolume, and pass it to the relevant functions for mount point resolution and free space checks.

This ensures that kdump can now be reliably configured with a dump target located on a btrfs subvolume.


___

### **PR Type**
Enhancement, Tests


___

### **Description**
- Add btrfs subvolume support for kdump dump targets

- Implement helper function to extract subvolume from mount options

- Update mount point resolution to handle btrfs subvolumes correctly

- Add comprehensive unit tests for new btrfs functionality


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Dump Target Detection"] -->|Extract subvol| B["get_btrfs_subvol_from_mntopt"]
  B -->|Pass subvol| C["get_mntpoint_from_target"]
  C -->|Resolve mount point| D["Mount Point Resolution"]
  A -->|Check filesystem| E["get_fs_type_from_target"]
  E -->|If btrfs| B
  D -->|Calculate space| F["get_fs_size"]
  F -->|Check available space| G["check_size"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>kdump-lib-initramfs.sh</strong><dd><code>Add btrfs subvolume mount point resolution</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

kdump-lib-initramfs.sh

<ul><li>Add <code>get_btrfs_subvol_from_mntopt</code> function to extract subvolume name <br>from mount options<br> <li> Modify <code>get_mntpoint_from_target</code> to accept optional subvolume parameter<br> <li> When subvolume is provided, search for mount entries matching the <br>subvolume pattern<br> <li> Fallback to original logic when subvolume is not provided</ul>


</details>


  </td>
  <td><a href="https://github.com/coiby/kdump-utils/pull/27/files#diff-72a7f9d881bb73d9d99a480c02a00c411ed24a6102c33c3a9b49a3e00f919d02">+18/-4</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>kdump-lib.sh</strong><dd><code>Integrate btrfs subvolume handling in mount resolution</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

kdump-lib.sh

<ul><li>Update <code>get_bind_mount_source</code> to use new <code>get_btrfs_subvol_from_mntopt</code> <br>helper<br> <li> Pass extracted subvolume to <code>get_mntpoint_from_target</code> function<br> <li> Simplify btrfs subvolume extraction logic by reusing helper function<br> <li> Update <code>get_kdump_mntpoint_from_target</code> to accept and forward subvolume <br>parameter</ul>


</details>


  </td>
  <td><a href="https://github.com/coiby/kdump-utils/pull/27/files#diff-b31a5837a63c042a38ac277903c137ebcd0c84560906acd84eb4ee77319c7d72">+6/-7</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>mkdumprd</strong><dd><code>Add btrfs subvolume support in dump target handling</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

mkdumprd

<ul><li>Detect btrfs filesystem and extract subvolume in <code>to_mount</code> function<br> <li> Pass subvolume to <code>get_kdump_mntpoint_from_target</code> for correct mount <br>point<br> <li> Update <code>get_fs_size</code> calls to include subvolume parameter<br> <li> Modify <code>check_size</code> function signature to accept subvolume parameter<br> <li> Update <code>handle_default_dump_target</code> to detect and pass subvolume <br>information</ul>


</details>


  </td>
  <td><a href="https://github.com/coiby/kdump-utils/pull/27/files#diff-37c8bf1f7a3940c8c32ccebdf7383edf9e743d96b13bf2900757a9b94fc170c8">+16/-8</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>module-setup.sh</strong><dd><code>Enable btrfs subvolume detection in dracut module</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

dracut/99kdumpbase/module-setup.sh

<ul><li>Extract mount options and filesystem type in <br><code>default_dump_target_install_conf</code><br> <li> Detect btrfs filesystem and extract subvolume name<br> <li> Pass subvolume to <code>get_mntpoint_from_target</code> for proper mount point <br>resolution<br> <li> Ensure correct mount point identification for btrfs subvolume targets</ul>


</details>


  </td>
  <td><a href="https://github.com/coiby/kdump-utils/pull/27/files#diff-ee155d1ee2beb1a151fa7366f71de6c8fee5887c78f4a346d0b5e4c505d19f5d">+8/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>kdump-lib-initramfs_spec.sh</strong><dd><code>Add unit tests for btrfs subvolume functions</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

spec/kdump-lib-initramfs_spec.sh

<ul><li>Add mock data for btrfs subvolume test case with <code>/dev/nvme0n1p3</code><br> <li> Update <code>get_mntpoint_from_target</code> test parameters to include subvolume <br>argument<br> <li> Add comprehensive test suite for <code>get_btrfs_subvol_from_mntopt</code> function<br> <li> Test various mount option formats including subvol at different <br>positions and with @ prefix</ul>


</details>


  </td>
  <td><a href="https://github.com/coiby/kdump-utils/pull/27/files#diff-a748969fdb8c271a30077f90e86a742897349fcb688aec48caf1d2cba8cf6fdb">+44/-6</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>kdump-lib_spec.sh</strong><dd><code>Add btrfs subvolume integration tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

spec/kdump-lib_spec.sh

<ul><li>Add new test suite for <code>get_kdump_mntpoint_from_target</code> with btrfs <br>subvolume support<br> <li> Mock <code>get_mntpoint_from_target</code> to simulate different subvolume mount <br>scenarios<br> <li> Test root filesystem, home subvolume, and backup subvolume cases<br> <li> Verify correct mount point mapping for subvolume targets</ul>


</details>


  </td>
  <td><a href="https://github.com/coiby/kdump-utils/pull/27/files#diff-681f73d40eb15c64b168f2498f990071f4d0fcc5eb3380050dc1b782b47799af">+48/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

