### PR TITLE
Add device by UUID if FIPS is enabled

### DIFF
--- a/mkdumprd
+++ b/mkdumprd
@@ -421,8 +421,10 @@ if ! is_fadump_capable; then
 	# to /sysroot beforehand.
 	if [[ $(cat /proc/sys/crypto/fips_enabled 2> /dev/null) == 1 ]]; then
 		_boot_source=$(findmnt -n -o SOURCE --target /boot)
+		_dev_uuid=$(blkid -s UUID -o value "$_boot_source")
+		_disk_uuid=$("/dev/disk/by-uuid/$_dev_uuid")
 		if mountpoint -q /boot; then
-			dracut_args+=(--add-device "$_boot_source")
+			dracut_args+=(--add-device "$_disk_uuid")
 		else
 			add_mount "$_boot_source"
 		fi


### PR DESCRIPTION
### **User description**
mkdumprd has a code to add a disk to kdump initramfs, in case FIPS is enabled and /boot is on a separate partition. This code used to work, since dracut was not force checking that added disk is in fact available. Since dracut commit c79fc8f dracut in fact checks for added device, and since disk name could have been changed between live system and kdump initramfs, kdump can fail. To resolve this problem add disk by UUID, not by disk name.


___

### **PR Type**
Bug fix


___

### **Description**
- Replace disk name with UUID when adding device for FIPS

- Resolves dracut validation failures due to device name changes

- Uses blkid to extract UUID from boot partition source

- Constructs device path via /dev/disk/by-uuid for reliability


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Boot source device name"] -->|"blkid extracts UUID"| B["Device UUID"]
  B -->|"Construct path"| C["/dev/disk/by-uuid/UUID"]
  C -->|"Pass to dracut"| D["--add-device parameter"]
  E["Dracut validation"] -->|"Resolves device availability check"| F["Success"]
  D --> E
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>mkdumprd</strong><dd><code>Replace device name with UUID for FIPS boot handling</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

mkdumprd

<ul><li>Extract UUID from boot partition using <code>blkid</code> command<br> <li> Construct device path via <code>/dev/disk/by-uuid/</code> instead of using device <br>name<br> <li> Pass UUID-based device path to dracut <code>--add-device</code> parameter<br> <li> Ensures device availability validation succeeds across system reboots</ul>


</details>


  </td>
  <td><a href="https://github.com/coiby/kdump-utils/pull/28/files#diff-37c8bf1f7a3940c8c32ccebdf7383edf9e743d96b13bf2900757a9b94fc170c8">+3/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

