### PR TITLE
Maximize the reserved size in osbuild case

### DIFF
--- a/gen-kdump-sysconfig.sh
+++ b/gen-kdump-sysconfig.sh
@@ -49,7 +49,7 @@ fi
 #
 # Generate the config file
 #
-cat <<EOF
+cat << EOF
 # Kernel Version string for the -kdump kernel, such as 2.6.13-1544.FC5kdump
 # If no version is specified, then the init script will try to find a
 # kdump kernel with the same version number as the running kernel.

--- a/kdump-lib.sh
+++ b/kdump-lib.sh
@@ -946,13 +946,16 @@ _crashkernel_parse()
 
 # $1 crashkernel command line parameter
 # $2 size to be added
+# $3 optionally skip the first n items in command line
 _crashkernel_add()
 {
-	local ck delta ret
+	local ck delta skip ret
 	local range size offset
+	local count=0
 
 	ck="$1"
 	delta="$2"
+	skip="${3:-0}" # Default to 0 if third parameter not provided
 	ret=""
 
 	while IFS=';' read -r size range offset; do
@@ -967,8 +970,12 @@ _crashkernel_add()
 			ret+="$range:"
 		fi
 
-		size=$(memsize_add "$size" "$delta") || return 1
+		if ((count >= skip)); then
+			size=$(memsize_add "$size" "$delta") || return 1
+		fi
+
 		ret+="$size,"
+		((count++))
 	done < <(_crashkernel_parse "$ck")
 
 	echo "${ret%,}"

--- a/kdump-lib.sh
+++ b/kdump-lib.sh
@@ -38,6 +38,25 @@ is_sme_or_sev_active()
 	journalctl -q --dmesg --grep "^Memory Encryption Features active: AMD (SME|SEV)$" > /dev/null 2>&1
 }
 
+# read the value of an environ variable from given environ file path
+#
+# The environment variable entries in /proc/[pid]/environ are separated
+# by null bytes instead of by spaces.
+#
+# $1: environment variable
+# $2: environ file path
+read_proc_environ_var()
+{
+	local _var=$1 _environ_path=$2
+	sed -n -E "s/.*(^|\x00)${_var}=([^\x00]*).*/\2/p" < "$_environ_path"
+}
+
+_OSBUILD_ENVIRON_PATH='/proc/1/environ'
+_is_osbuild()
+{
+	[[ $(read_proc_environ_var container "$_OSBUILD_ENVIRON_PATH") == bwrap-osbuild ]]
+}
+
 has_command()
 {
 	[[ -x $(command -v "$1") ]]

--- a/kdump-lib.sh
+++ b/kdump-lib.sh
@@ -989,6 +989,7 @@ kdump_get_arch_recommend_crashkernel()
 {
 	local _arch _ck_cmdline _dump_mode
 	local _delta=0
+	local _skip=0
 
 	if [[ -z $1 ]]; then
 		if is_fadump_capable; then
@@ -1015,6 +1016,8 @@ kdump_get_arch_recommend_crashkernel()
 		else
 			_running_kernel=$2
 		fi
+		# skip adding additional memory for small-memory machine
+		_skip=1
 
 		# the naming convention of 64k variant suffixes with +64k, e.g. "vmlinuz-5.14.0-312.el9.aarch64+64k"
 		if echo "$_running_kernel" | grep -q 64k; then
@@ -1038,7 +1041,7 @@ kdump_get_arch_recommend_crashkernel()
 		fi
 	fi
 
-	echo -n "$(_crashkernel_add "$_ck_cmdline" "${_delta}M")"
+	echo -n "$(_crashkernel_add "$_ck_cmdline" "${_delta}M" "$_skip")"
 }
 
 # return recommended size based on current system RAM size

--- a/kdumpctl
+++ b/kdumpctl
@@ -1210,6 +1210,53 @@ prepare_luks()
 	done
 }
 
+get_crashkernel_bounce_buffer_size()
+{
+	local lines first_line start_hex end_hex start_dec end_dec size_bytes
+
+	mapfile -t lines < <(grep "Crash kernel" /proc/iomem)
+
+	if [ ${#lines[@]} -le 1 ]; then
+		echo 0
+		return
+	fi
+
+	first_line=${lines[0]}
+	# Extract start and end addresses
+	start_hex=$(echo "$first_line" | awk '{split($1, a, "-"); print a[1]}')
+	end_hex=$(echo "$first_line" | awk '{split($1, a, "-"); print a[2]}')
+	# Convert hex to decimal
+	start_dec=$((0x$start_hex))
+	end_dec=$((0x$end_hex))
+	# Calculate size in bytes
+	size_bytes=$((end_dec - start_dec + 1))
+	echo "$size_bytes"
+}
+
+suggest_crashkernel_reset()
+{
+	local _crashkernel _recommend_value _actual_value _bounce_buff_size
+
+	_crashkernel=$(sed -n 's/.*crashkernel=\([^ ]*\).*/\1/p' /proc/cmdline)
+	[[ $(kdump_get_conf_val auto_reset_crashkernel) == no ]] && return
+	# At present, the crashkernel value for fadump is not dynamic
+	is_fadump_capable && return
+
+	_recommend_value=$(kdump_get_arch_recommend_size)
+	# The crashkernel formula does not account for DMA-bounce buffers,
+	# unlike kexec_crash_size which does. Systems using DMA-bounce buffers
+	# should factor this into the calculation.
+	_bounce_buff_size=$(get_crashkernel_bounce_buffer_size)
+	_recommend_value=$(memsize_add "$_recommend_value" "$_bounce_buff_size")
+	_recommend_value=$(to_bytes "$_recommend_value")
+	_actual_value=$(cat /sys/kernel/kexec_crash_size)
+
+	if [ "$_recommend_value" -lt "$_actual_value" ]; then
+		dwarn "The reserved crashkernel is abundant. Using 'kdumpctl reset-crashkernel' to reset kernel cmdline. It will take effect in the next boot"
+		dwarn "To release the abundant memory immediately, you can run: 'kdumpctl stop; echo $_recommend_value >/sys/kernel/kexec_crash_size; kdumpctl start'"
+	fi
+}
+
 start()
 {
 	check_dump_feasibility || return
@@ -1243,6 +1290,7 @@ start()
 	start_dump || return
 
 	dinfo "Starting kdump: [OK]"
+	suggest_crashkernel_reset
 	return 0
 }
 

--- a/kdumpctl
+++ b/kdumpctl
@@ -1970,25 +1970,6 @@ reset_crashkernel_after_update()
 	done
 }
 
-# read the value of an environ variable from given environ file path
-#
-# The environment variable entries in /proc/[pid]/environ are separated
-# by null bytes instead of by spaces.
-#
-# $1: environment variable
-# $2: environ file path
-read_proc_environ_var()
-{
-	local _var=$1 _environ_path=$2
-	sed -n -E "s/.*(^|\x00)${_var}=([^\x00]*).*/\2/p" < "$_environ_path"
-}
-
-_OSBUILD_ENVIRON_PATH='/proc/1/environ'
-_is_osbuild()
-{
-	[[ $(read_proc_environ_var container "$_OSBUILD_ENVIRON_PATH") == bwrap-osbuild ]]
-}
-
 reset_crashkernel_for_installed_kernel()
 {
 	local _installed_kernel _grub_entry_index _kernel _old_ck _old_fadump

--- a/spec/kdump-lib_spec.sh
+++ b/spec/kdump-lib_spec.sh
@@ -51,7 +51,7 @@ Describe 'kdump-lib'
 	End
 
 	Describe "_crashkernel_add()"
-		Context "For valid input values"
+		Context "For valid input values with two arguments (skip defaults to 0)"
 			Parameters
 				"2G-4G:256M,4G-64G:320M,64G-:576M" "100M" "2G-4G:356M,4G-64G:420M,64G-:676M"
 				"2G-4G:256M" "100" "2G-4G:268435556" # avoids any rounding when size % 1024 != 0
@@ -74,6 +74,25 @@ Describe 'kdump-lib'
 				The output should equal "$3"
 			End
 		End
+
+		Context "For valid input values with three arguments (explicit skip)"
+			Parameters
+				"2G-4G:256M,4G-64G:320M,64G-:576M" "100M" "1" "2G-4G:256M,4G-64G:420M,64G-:676M"
+				"2G-4G:256M,4G-64G:320M,64G-:576M" "100M" "2" "2G-4G:256M,4G-64G:320M,64G-:676M"
+				"2G-4G:256M,4G-64G:320M,64G-:576M" "100M" "3" "2G-4G:256M,4G-64G:320M,64G-:576M"
+				"2G-4G:256M,4G-64G:320M,64G-:576M@4G" "100M" "1" "2G-4G:256M,4G-64G:420M,64G-:676M@4G"
+				"2G-4G:1G,4G-64G:2G,64G-:3G@4G" "100M" "1" "2G-4G:1G,4G-64G:2148M,64G-:3172M@4G"
+				"2G-4G:10000K,4G-64G:20000K" "100M" "1" "2G-4G:10000K,4G-64G:122400K"
+				"1M@1G" "1K" "1" "1M@1G"
+				"128G-1T:4G,10T-100T:1T" "1G" "1" "128G-1T:4G,10T-100T:1025G"
+				"1K,low" "1" "1" "1K,low"
+			End
+			It "should add delta to values after ':' starting after skip count"
+				When call _crashkernel_add "$1" "$2" "$3"
+				The output should equal "$4"
+			End
+		End
+
 		Context "For invalid input values"
 			Parameters
 				"2G-4G:256M.4G-64G:320M" "100M"


### PR DESCRIPTION
### **User description**
At present, the deduction of the proper crashkernel value depends on
detecting platform details. However, more and more platforms are now
deployed using OSTree images, which means kdump-utils cannot retrieve
complete platform information. This often leads to an underestimation of
the memory required by the kdump kernel, increasing the risk of
out-of-memory (OOM) issues.

To mitigate this situation, we choose to maximize the reserved
crashkernel size in the osbuild case, and recommend users to update the
kernel command line and release the excess reserved memory after reboot.

That is done by: kdumpctl stop; echo $_recommend_value >/sys/kernel/kexec_crash_size; kdumpctl start


___

### **PR Type**
Enhancement, Bug fix


___

### **Description**
- Maximize crashkernel reservation in OSTree/osbuild deployments
  - Add `maximize_crashkernel` flag to skip hardware detection
  - Extend `_crashkernel_add()` with skip parameter for selective range adjustment

- Skip additional memory for small-memory aarch64 machines
  - Prevent OOM on systems lacking hardware features (Mellanox, SMMU)
  - Apply skip logic to first crashkernel range only

- Move OSTree detection utilities to kdump-lib.sh
  - Relocate `_is_osbuild()` and `read_proc_environ_var()` functions
  - Enable reuse across kdump-lib and kdumpctl modules

- Add crashkernel reset suggestion on kdump start
  - Calculate bounce buffer size from /proc/iomem
  - Warn users when reserved memory exceeds recommended value


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["OSTree Detection<br/>_is_osbuild()"] -->|Set Flag| B["maximize_crashkernel=true"]
  B -->|Skip Hardware Checks| C["Skip SME/SEV/MLX5/SMMU Detection"]
  B -->|Skip First Range| D["_crashkernel_add with skip param"]
  D -->|Adjust Ranges| E["Maximize Crashkernel Size"]
  E -->|On Start| F["suggest_crashkernel_reset()"]
  F -->|Compare Actual vs Recommended| G["Warn User if Abundant"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>kdump-lib.sh</strong><dd><code>OSTree detection and selective crashkernel range adjustment</code></dd></summary>
<hr>

kdump-lib.sh

<ul><li>Add <code>maximize_crashkernel</code> global flag to control hardware detection <br>bypass<br> <li> Implement <code>read_proc_environ_var()</code> and <code>_is_osbuild()</code> functions for <br>OSTree detection<br> <li> Extend <code>_crashkernel_add()</code> with optional third parameter to skip first <br>N ranges<br> <li> Add <code>is_aarch64_64k_kernel()</code> helper function with maximize flag support<br> <li> Modify hardware detection functions (<code>is_sme_or_sev_active()</code>, <br><code>has_mlx5()</code>, <code>has_aarch64_smmu()</code>) to short-circuit when maximize flag is <br>set<br> <li> Update <code>kdump_get_arch_recommend_crashkernel()</code> to set maximize flag for <br>osbuild and skip first range for aarch64</ul>


</details>


  </td>
  <td><a href="https://github.com/coiby/kdump-utils/pull/31/files#diff-b31a5837a63c042a38ac277903c137ebcd0c84560906acd84eb4ee77319c7d72">+47/-8</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>kdumpctl</strong><dd><code>Add crashkernel reset suggestion and bounce buffer calculation</code></dd></summary>
<hr>

kdumpctl

<ul><li>Add <code>get_crashkernel_bounce_buffer_size()</code> function to calculate DMA <br>bounce buffer size from /proc/iomem<br> <li> Implement <code>suggest_crashkernel_reset()</code> function to warn users when <br>reserved crashkernel exceeds recommended value<br> <li> Call <code>suggest_crashkernel_reset()</code> after successful kdump start to <br>provide reset guidance<br> <li> Move <code>read_proc_environ_var()</code> and <code>_is_osbuild()</code> functions to <br>kdump-lib.sh (removed from kdumpctl)</ul>


</details>


  </td>
  <td><a href="https://github.com/coiby/kdump-utils/pull/31/files#diff-03a781ca2c9b1db0905a613a6d931f6fb0bde0803a2ccbe53042702246aa9a2e">+48/-19</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>kdump-lib_spec.sh</strong><dd><code>Extend crashkernel_add tests for skip parameter</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

spec/kdump-lib_spec.sh

<ul><li>Update test context description for <code>_crashkernel_add()</code> with two <br>arguments<br> <li> Add comprehensive test cases for three-argument variant with explicit <br>skip parameter<br> <li> Test skip behavior across multiple scenarios: different ranges, memory <br>units, and edge cases<br> <li> Verify that skipped ranges remain unchanged while subsequent ranges <br>receive delta adjustment</ul>


</details>


  </td>
  <td><a href="https://github.com/coiby/kdump-utils/pull/31/files#diff-681f73d40eb15c64b168f2498f990071f4d0fcc5eb3380050dc1b782b47799af">+20/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

