### PR TITLE
kexec-kdump-howto.txt: update paragraphs related to disable_cpu_apicid

### DIFF
--- a/kexec-kdump-howto.txt
+++ b/kexec-kdump-howto.txt
@@ -935,10 +935,14 @@ For example:
 
 Notes on how to use multiple cpus on a capture kernel on x86 system:
 
-Make sure that you are using a kernel that supports disable_cpu_apicid
-kernel option as a capture kernel, which is needed to avoid x86 specific
-hardware issue (*). The disable_cpu_apicid kernel option is automatically
-appended by kdumpctl script and is ignored if the kernel doesn't support it.
+The disable_cpu_apicid kernel option is automatically appended by kdumpctl
+script to capture kernel to avoid x86 specific hardware issue and is ignored
+if the kernel doesn't support it. For newer kernels that contain commit
+5c5682b9f87a ("x86/cpu: Detect real BSP on crash kernels"), this hardware
+issue on x86 has been fixed in the kernel. However, adding disable_cpu_apicid
+is not harmful for newer kernels, and it is still added to the capture kernel
+to maintain backward compatibility with older kernels that do not contain
+commit 5c5682b9f87a.
 
 You need to specify how many cpus to be used in a capture kernel by specifying
 the number of cpus in nr_cpus kernel option in /etc/sysconfig/kdump. nr_cpus
@@ -948,9 +952,9 @@ You should use necessary and sufficient number of cpus on a capture kernel.
 Warning: Don't use too many cpus on a capture kernel, or the capture kernel
 may lead to panic due to Out Of Memory.
 
-(*) Without disable_cpu_apicid kernel option, capture kernel may lead to
-hang, system reset or power-off at boot, depending on your system and runtime
-situation at the time of crash.
+(*) Without the disable_cpu_apicid kernel option, a capture kernel that does
+not contain commit 5c5682b9f87a may hang, reset, or power-off at boot,
+depending on your system and runtime situation at the time of the crash.
 
 
 Debugging Tips


### PR DESCRIPTION
### **User description**
Long before, to support multiple CPUs on x86_64, 'disable_cpu_apicid='
was introduced. It's to avoid the case when nr_cpus=xx is added, while
crashed cpu is not BSP cpu, then the crashed CPU will send INIT to BSP
cpu in kdump kernel. While the BSP cpu being reinitialized when
receiving INIT in the 2nd time will cause kdump kernel collapsing.

Now, in kernel commit 5c5682b9f87a ("x86/cpu: Detect real BSP on crash
kernels"), the requirement of disable_cpu_apicid has been taken off by
detecting real BSP on crashed kernel and not sending INIT to it.
Now testing passed on x86_64 system w/ or w/o disable_cpu_apicid and the
kernel message can be seen as below.

===============
CPU topo: Boot CPU APIC ID not the first enumerated APIC ID: 1e != 0
CPU topo: Crash kernel detected. Disabling real BSP to prevent machine INIT
===============

However, sometime older kernel which doesn't contain commit 5c5682b9f87a
is still loaded in newer OS. To keep good back compatibility, still
adding disable_cpu_apicid to capture kernel. It's not harmful on newer
kernel containing commit 5c5682b9f87a.


___

### **PR Type**
Documentation


___

### **Description**
- Update documentation on `disable_cpu_apicid` kernel option for x86 kdump

- Clarify that kernel commit 5c5682b9f87a fixes the underlying hardware issue

- Explain backward compatibility rationale for still using `disable_cpu_apicid`

- Refine warning note to specify affected older kernels


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Old Documentation"] -->|"Clarify fix in newer kernels"| B["Updated disable_cpu_apicid guidance"]
  B -->|"Explain backward compatibility"| C["Support both old and new kernels"]
  B -->|"Refine warning scope"| D["Specify affected kernel versions"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>kexec-kdump-howto.txt</strong><dd><code>Clarify disable_cpu_apicid backward compatibility and kernel fix</code></dd></summary>
<hr>

kexec-kdump-howto.txt

<ul><li>Rewrote main paragraph explaining that <code>disable_cpu_apicid</code> is <br>automatically appended for backward compatibility<br> <li> Added context about kernel commit 5c5682b9f87a fixing the x86 hardware <br>issue in newer kernels<br> <li> Clarified that adding <code>disable_cpu_apicid</code> is harmless for newer kernels<br> <li> Updated footnote to specify that the hardware issue only affects older <br>kernels without the fix</ul>


</details>


  </td>
  <td><a href="https://github.com/coiby/kdump-utils/pull/35/files#diff-da0895f8be237906167e0b224907a7bbd30e3bb0b329962a94226e2bfde88521">+11/-7</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

